### PR TITLE
Topic publishers and names updates

### DIFF
--- a/Runtime/Prefabs/lolo_auv_v1.prefab
+++ b/Runtime/Prefabs/lolo_auv_v1.prefab
@@ -707,7 +707,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 10a8919bb6be9cfc88e08395412d871b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/thruster_port_fb
+  topic: actuators/thruster_port_fb
   frequency: 10
   ignoreSensorState: 0
 --- !u!114 &5378080136670906774
@@ -722,7 +722,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c429a099bc8d99179a44603b0781227c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/thruster_port_cmd
+  topic: actuators/thruster_port_cmd
   expectedFrequency: 2
   resetting: 1
   receivedFrequency: 0
@@ -892,7 +892,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 10a8919bb6be9cfc88e08395412d871b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/thruster_stbd_fb
+  topic: actuators/thruster_strb_fb
   frequency: 10
   ignoreSensorState: 0
 --- !u!114 &6309090320770876276
@@ -907,7 +907,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c429a099bc8d99179a44603b0781227c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/thruster_stbd_cmd
+  topic: actuators/thruster_strb_cmd
   expectedFrequency: 2
   resetting: 1
   receivedFrequency: 0
@@ -1160,7 +1160,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6c1407c79a8032a329313e14db655bcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: dr/lat_lon
+  topic: smarc/latlon
   frequency: 10
   ignoreSensorState: 1
 --- !u!114 &2186974322604431293
@@ -1417,7 +1417,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 10a8919bb6be9cfc88e08395412d871b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/vert_thruster_front_port_fb
+  topic: actuators/vertical_thruster_front_port_fb
   frequency: 10
   ignoreSensorState: 0
 --- !u!114 &3360185221928561318
@@ -1432,7 +1432,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c429a099bc8d99179a44603b0781227c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/vert_thruster_front_port_cmd
+  topic: actuators/vertical_thruster_front_port_cmd
   expectedFrequency: 2
   resetting: 1
   receivedFrequency: 0
@@ -1504,7 +1504,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 771d0adfb2667593a8c266a12060997f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/elevon_stbd_cmd
+  topic: actuators/elevon_strb_cmd
   expectedFrequency: -1
   resetting: 1
   receivedFrequency: 0
@@ -1601,7 +1601,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 10a8919bb6be9cfc88e08395412d871b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/vert_thruster_front_stbd_fb
+  topic: actuators/vertical_thruster_front_strb_fb
   frequency: 10
   ignoreSensorState: 0
 --- !u!114 &1286021298945174430
@@ -1616,7 +1616,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c429a099bc8d99179a44603b0781227c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/vert_thruster_front_stbd_cmd
+  topic: actuators/vertical_thruster_front_strb_cmd
   expectedFrequency: 2
   resetting: 1
   receivedFrequency: 0
@@ -1873,7 +1873,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 10a8919bb6be9cfc88e08395412d871b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/vert_thruster_back_stbd_fb
+  topic: actuators/vertical_thruster_back_strb_fb
   frequency: 10
   ignoreSensorState: 0
 --- !u!114 &3274884573070327101
@@ -1888,7 +1888,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c429a099bc8d99179a44603b0781227c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/vert_thruster_back_stbd_cmd
+  topic: actuators/vertical_thruster_back_strb_cmd
   expectedFrequency: 2
   resetting: 1
   receivedFrequency: 0
@@ -2008,7 +2008,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b53b4caa09486ed69afd7310efb6dbaf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/battery
+  topic: smarc/battery_percent
   frequency: 10
   ignoreSensorState: 0
 --- !u!1 &2736854850070752478
@@ -2674,7 +2674,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 771d0adfb2667593a8c266a12060997f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/elevon_port_cmd
+  topic: actuators/elevon_port_cmd
   expectedFrequency: -1
   resetting: 1
   receivedFrequency: 0
@@ -3088,7 +3088,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 10a8919bb6be9cfc88e08395412d871b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/vert_thruster_back_port_fb
+  topic: actuators/vertical_thruster_back_port_fb
   frequency: 10
   ignoreSensorState: 0
 --- !u!114 &6894557112106137073
@@ -3103,7 +3103,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c429a099bc8d99179a44603b0781227c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/vert_thruster_back_port_cmd
+  topic: actuators/vertical_thruster_back_port_cmd
   expectedFrequency: 2
   resetting: 1
   receivedFrequency: 0
@@ -3511,7 +3511,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0488af2a38628407dba8adb3eb1a253b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/odom_gt
+  topic: smarc/odom
   frequency: 10
   ignoreSensorState: 0
   useNED: 0
@@ -4118,7 +4118,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 771d0adfb2667593a8c266a12060997f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/rudder_stbd_cmd
+  topic: actuators/rudder_cmd
   expectedFrequency: -1
   resetting: 1
   receivedFrequency: 0
@@ -5610,6 +5610,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ThrustSteering: 0
+  ThrustRolling: 1
+  ThrustPitching: 1
   elevatorHingeGo: {fileID: 8939564543920937555}
   elevonPortHingeGo: {fileID: 3088666195858771038}
   elevonStbdHingeGo: {fileID: 1851872486568332449}
@@ -6756,7 +6758,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 771d0adfb2667593a8c266a12060997f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/rudder_port_cmd
+  topic: actuators/rudder_cmd
   expectedFrequency: -1
   resetting: 1
   receivedFrequency: 0
@@ -6844,7 +6846,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 771d0adfb2667593a8c266a12060997f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  topic: core/elevator_cmd
+  topic: actuators/elevator_cmd
   expectedFrequency: -1
   resetting: 1
   receivedFrequency: 0

--- a/Runtime/Scripts/VehicleComponents/ROS/Core/ROSPublisher.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Core/ROSPublisher.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using ROSMessage = Unity.Robotics.ROSTCPConnector.MessageGeneration.Message;
 using Unity.Robotics.Core;
+using Utils = DefaultNamespace.Utils;
 
 
 namespace VehicleComponents.ROS.Core
@@ -21,6 +22,8 @@ namespace VehicleComponents.ROS.Core
         protected PublishableType sensor;
         protected RosMsgType ROSMsg;
 
+        protected string frame_id_prefix = "";
+
         bool registered = false;
 
         
@@ -36,6 +39,8 @@ namespace VehicleComponents.ROS.Core
                 rosCon.RegisterPublisher<RosMsgType>(topic);
                 registered = true;
             }
+            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
+            frame_id_prefix = robotGO.name;
             InitPublisher();
         }
 

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/Battery_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/Battery_Pub.cs
@@ -1,7 +1,6 @@
 using UnityEngine;
 using RosMessageTypes.Sensor;
 using Unity.Robotics.Core; //Clock
-using Utils = DefaultNamespace.Utils;
 
 using SensorBattery = VehicleComponents.Sensors.Battery;
 using VehicleComponents.ROS.Core;
@@ -13,9 +12,7 @@ namespace VehicleComponents.ROS.Publishers
     {
         protected override void InitPublisher()
         {
-            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
-            string prefix = robotGO.name;
-            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
+            ROSMsg.header.frame_id = $"{frame_id_prefix}/{sensor.linkName}";
         }
 
         protected override void UpdateMessage()

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/Battery_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/Battery_Pub.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using RosMessageTypes.Sensor;
 using Unity.Robotics.Core; //Clock
+using Utils = DefaultNamespace.Utils;
 
 using SensorBattery = VehicleComponents.Sensors.Battery;
 using VehicleComponents.ROS.Core;
@@ -10,6 +11,13 @@ namespace VehicleComponents.ROS.Publishers
     [RequireComponent(typeof(SensorBattery))]
     class Battery_Pub: ROSPublisher<BatteryStateMsg, SensorBattery>
     {
+        protected override void InitPublisher()
+        {
+            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
+            string prefix = robotGO.name;
+            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
+        }
+
         protected override void UpdateMessage()
         {
             ROSMsg.voltage = sensor.currentVoltage;

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/CameraImageCompressed_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/CameraImageCompressed_Pub.cs
@@ -20,7 +20,7 @@ namespace VehicleComponents.ROS.Publishers
         protected override void InitPublisher()
         {
             ROSMsg.format = "rgb8;jpeg compressed rgb8";
-            ROSMsg.header.frame_id = sensor.linkName;
+            ROSMsg.header.frame_id = $"{frame_id_prefix}/{sensor.linkName}";
         }
 
         protected override void UpdateMessage()

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/CameraImage_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/CameraImage_Pub.cs
@@ -21,7 +21,7 @@ namespace VehicleComponents.ROS.Publishers
             ROSMsg.width = (uint) textureWidth;
             ROSMsg.is_bigendian = 0;
             ROSMsg.step = (uint)(3*textureWidth);
-            ROSMsg.header.frame_id = sensor.linkName;
+            ROSMsg.header.frame_id = $"{frame_id_prefix}/{sensor.linkName}";
         }
 
         protected override void UpdateMessage()

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/CameraInfo_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/CameraInfo_Pub.cs
@@ -35,7 +35,7 @@ namespace VehicleComponents.ROS.Publishers
             ROSMsg.P = new double[12];
             ROSMsg.height = (uint) sensor.textureHeight;
             ROSMsg.width = (uint) sensor.textureWidth;
-            ROSMsg.header.frame_id = sensor.linkName;
+            ROSMsg.header.frame_id = $"{frame_id_prefix}/{sensor.linkName}";
             cam = GetComponent<Camera>();
         }
 

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/DVL_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/DVL_Pub.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using Unity.Robotics.Core; //Clock
 using Unity.Robotics.ROSTCPConnector.ROSGeometry;
 using RosMessageTypes.Smarc;
-using Utils = DefaultNamespace.Utils;
 
 using SensorDVL = VehicleComponents.Sensors.DVL;
 using VehicleComponents.ROS.Core;
@@ -18,9 +17,7 @@ namespace VehicleComponents.ROS.Publishers
 
         protected override void InitPublisher()
         {
-            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
-            string prefix = robotGO.name;
-            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
+            ROSMsg.header.frame_id = $"{frame_id_prefix}/{sensor.linkName}";
             beamMsgs = new DVLBeamMsg[sensor.numBeams];
             for(int i=0; i < sensor.numBeams; i++)
             {

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/DVL_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/DVL_Pub.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using Unity.Robotics.Core; //Clock
 using Unity.Robotics.ROSTCPConnector.ROSGeometry;
 using RosMessageTypes.Smarc;
+using Utils = DefaultNamespace.Utils;
 
 using SensorDVL = VehicleComponents.Sensors.DVL;
 using VehicleComponents.ROS.Core;
@@ -17,7 +18,9 @@ namespace VehicleComponents.ROS.Publishers
 
         protected override void InitPublisher()
         {
-            ROSMsg.header.frame_id = sensor.linkName;
+            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
+            string prefix = robotGO.name;
+            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
             beamMsgs = new DVLBeamMsg[sensor.numBeams];
             for(int i=0; i < sensor.numBeams; i++)
             {

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/DepthPressure_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/DepthPressure_Pub.cs
@@ -1,7 +1,6 @@
 using UnityEngine;
 using RosMessageTypes.Sensor;
 using Unity.Robotics.Core; //Clock
-using Utils = DefaultNamespace.Utils;
 
 using SensorPressure = VehicleComponents.Sensors.DepthPressure;
 using VehicleComponents.ROS.Core;
@@ -14,9 +13,7 @@ namespace VehicleComponents.ROS.Publishers
     { 
         protected override void InitPublisher()
         {
-            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
-            string prefix = robotGO.name;
-            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
+            ROSMsg.header.frame_id = $"{frame_id_prefix}/{sensor.linkName}";
         }
 
         protected override void UpdateMessage()

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/DepthPressure_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/DepthPressure_Pub.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using RosMessageTypes.Sensor;
 using Unity.Robotics.Core; //Clock
+using Utils = DefaultNamespace.Utils;
 
 using SensorPressure = VehicleComponents.Sensors.DepthPressure;
 using VehicleComponents.ROS.Core;
@@ -13,7 +14,9 @@ namespace VehicleComponents.ROS.Publishers
     { 
         protected override void InitPublisher()
         {
-            ROSMsg.header.frame_id = sensor.linkName;
+            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
+            string prefix = robotGO.name;
+            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
         }
 
         protected override void UpdateMessage()

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/GPS_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/GPS_Pub.cs
@@ -1,7 +1,6 @@
 using UnityEngine;
 using RosMessageTypes.Sensor;
 using Unity.Robotics.Core; //Clock
-using Utils = DefaultNamespace.Utils;
 
 using SensorGPS = VehicleComponents.Sensors.GPS;
 using VehicleComponents.ROS.Core;
@@ -14,9 +13,7 @@ namespace VehicleComponents.ROS.Publishers
     { 
         protected override void InitPublisher()
         {
-            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
-            string prefix = robotGO.name;
-            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
+            ROSMsg.header.frame_id = $"{frame_id_prefix}/{sensor.linkName}";
         }
         
         protected override void UpdateMessage()

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/GPS_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/GPS_Pub.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using RosMessageTypes.Sensor;
 using Unity.Robotics.Core; //Clock
+using Utils = DefaultNamespace.Utils;
 
 using SensorGPS = VehicleComponents.Sensors.GPS;
 using VehicleComponents.ROS.Core;
@@ -11,6 +12,13 @@ namespace VehicleComponents.ROS.Publishers
     [RequireComponent(typeof(SensorGPS))]
     class GPS_Pub: ROSPublisher<NavSatFixMsg, SensorGPS>
     { 
+        protected override void InitPublisher()
+        {
+            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
+            string prefix = robotGO.name;
+            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
+        }
+        
         protected override void UpdateMessage()
         {
             ROSMsg.header.stamp = new TimeStamp(Clock.time);

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/IMU_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/IMU_Pub.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using RosMessageTypes.Sensor;
 using Unity.Robotics.Core; //Clock
 using Unity.Robotics.ROSTCPConnector.ROSGeometry;
-using Utils = DefaultNamespace.Utils;
 
 using SensorIMU = VehicleComponents.Sensors.IMU;
 using VehicleComponents.ROS.Core;
@@ -18,9 +17,7 @@ namespace VehicleComponents.ROS.Publishers
 
         protected override void InitPublisher()
         {
-            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
-            string prefix = robotGO.name;
-            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
+            ROSMsg.header.frame_id = $"{frame_id_prefix}/{sensor.linkName}";
         }
 
         protected override void UpdateMessage()

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/IMU_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/IMU_Pub.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using RosMessageTypes.Sensor;
 using Unity.Robotics.Core; //Clock
 using Unity.Robotics.ROSTCPConnector.ROSGeometry;
+using Utils = DefaultNamespace.Utils;
 
 using SensorIMU = VehicleComponents.Sensors.IMU;
 using VehicleComponents.ROS.Core;
@@ -14,9 +15,12 @@ namespace VehicleComponents.ROS.Publishers
     { 
         [Tooltip("If false, orientation is in ENU in ROS.")]
         public bool useNED = false;
+
         protected override void InitPublisher()
         {
-            ROSMsg.header.frame_id = sensor.linkName;
+            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
+            string prefix = robotGO.name;
+            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
         }
 
         protected override void UpdateMessage()

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/Odometry_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/Odometry_Pub.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using RosMessageTypes.Nav;
 using Unity.Robotics.Core; //Clock
 using Unity.Robotics.ROSTCPConnector.ROSGeometry;
+using Utils = DefaultNamespace.Utils;
 
 using SensorIMU = VehicleComponents.Sensors.IMU;
 using VehicleComponents.ROS.Core;
@@ -24,8 +25,10 @@ namespace VehicleComponents.ROS.Publishers
         }
         protected override void InitPublisher()
         {
+            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
+            string prefix = robotGO.name;
             ROSMsg.header.frame_id = "map_gt";
-            ROSMsg.child_frame_id = sensor.linkName;
+            ROSMsg.child_frame_id = $"{prefix}/{sensor.linkName}";
             ROSPosition = Vector3.zero;
         }
 

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/Odometry_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/Odometry_Pub.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using RosMessageTypes.Nav;
 using Unity.Robotics.Core; //Clock
 using Unity.Robotics.ROSTCPConnector.ROSGeometry;
-using Utils = DefaultNamespace.Utils;
 
 using SensorIMU = VehicleComponents.Sensors.IMU;
 using VehicleComponents.ROS.Core;
@@ -25,10 +24,8 @@ namespace VehicleComponents.ROS.Publishers
         }
         protected override void InitPublisher()
         {
-            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
-            string prefix = robotGO.name;
             ROSMsg.header.frame_id = "map_gt";
-            ROSMsg.child_frame_id = $"{prefix}/{sensor.linkName}";
+            ROSMsg.child_frame_id = $"{frame_id_prefix}/{sensor.linkName}";
             ROSPosition = Vector3.zero;
         }
 

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/PropellerFeedback_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/PropellerFeedback_Pub.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using RosMessageTypes.Smarc;
 using Unity.Robotics.Core; // Clock
+using Utils = DefaultNamespace.Utils;
 
 using Propeller = VehicleComponents.Actuators.Propeller;
 using VehicleComponents.ROS.Core;
@@ -20,6 +21,9 @@ namespace VehicleComponents.ROS.Publishers
                 enabled = false;
                 return;
             }
+            var robotGO = Utils.FindParentWithTag(gameObject, "robot", false);
+            string prefix = robotGO.name;
+            ROSMsg.header.frame_id = $"{prefix}/{sensor.linkName}";
         }
 
         protected override void UpdateMessage()

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/SSS_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/SSS_Pub.cs
@@ -15,7 +15,7 @@ namespace VehicleComponents.ROS.Publishers
     { 
         protected override void InitPublisher()
         {
-            ROSMsg.header.frame_id = sensor.linkName;
+            ROSMsg.header.frame_id = $"{frame_id_prefix}/{sensor.linkName}";
             ROSMsg.port_channel = new byte[sensor.NumBucketsPerBeam];
             ROSMsg.starboard_channel = new byte[sensor.NumBucketsPerBeam];
             ROSMsg.port_channel_angle_high = new byte[sensor.NumBucketsPerBeam];

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/SonarPointCloud_Pub.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/SonarPointCloud_Pub.cs
@@ -15,7 +15,7 @@ namespace VehicleComponents.ROS.Publishers
         public string frame_id="map_gt";
         protected override void InitPublisher()
         {
-            ROSMsg.header.frame_id = frame_id;
+            ROSMsg.header.frame_id = $"{frame_id_prefix}/{sensor.linkName}";
 
             ROSMsg.height = 1; // just one long list of points
             ROSMsg.width = (uint)sensor.TotalRayCount;


### PR DESCRIPTION
1. Updated the relevant sensor message publishers to prepend the robot's name to the link's name for the frame_id in the message header.
2. Updated the lolo_auv_v1 prefab to publish the available smarc-required topics with the right name, following: https://github.com/smarc-project/smarc2/blob/humble/messages/smarc_msgs/msg/Topics.msg

xoxo,
aldito
