### PR TITLE
fixed the TFTree issue. odom object no longer needed under vehicles

### DIFF
--- a/Runtime/Prefabs/Evolo.prefab
+++ b/Runtime/Prefabs/Evolo.prefab
@@ -189,8 +189,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 32ccbfb20e694c726875aa7c68c0bca7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 50
   topic: Lidar/imu
+  frequency: 50
   ignoreSensorState: 0
   useNED: 0
 --- !u!1 &563416717710840695
@@ -232,7 +232,7 @@ Transform:
   - {fileID: 6057045251702436358}
   - {fileID: 7930417288810016589}
   - {fileID: 3784376702739148248}
-  m_Father: {fileID: 2466823344739537690}
+  m_Father: {fileID: 8664524225559225572}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!54 &7526506965281460263
 Rigidbody:
@@ -375,6 +375,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8664524225559225572}
   - component: {fileID: 9041442465036777823}
+  - component: {fileID: 7905821354947278096}
   m_Layer: 0
   m_Name: Evolo
   m_TagString: robot
@@ -395,7 +396,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2466823344739537690}
+  - {fileID: 8843746628753723261}
   - {fileID: 8702555618869335524}
   - {fileID: 9181612218238451591}
   m_Father: {fileID: 0}
@@ -420,6 +421,22 @@ MonoBehaviour:
   maxRollAceleration: 25
   heightCorrection: 0.4
   speedMetersPerSecond: 0
+--- !u!114 &7905821354947278096
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1050158393429087721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78564e3e0c2d8c65cb6601a38bee530d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  topic: /tf
+  Suffix: _gt
+  BaseLinkName: base_link
+  Frequency: 10
 --- !u!1 &1357718168921322021
 GameObject:
   m_ObjectHideFlags: 0
@@ -547,8 +564,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4fb87cf5579908965bd1e8fd9984c1f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 10
   topic: cam_overhead/image_raw/compressed
+  frequency: 10
   ignoreSensorState: 0
   quality: 75
 --- !u!114 &8884937981894317977
@@ -563,8 +580,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b6639050ad5a83f6a4f0de5e9d7e935, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 10
   topic: cam_overhead/image_raw
+  frequency: 10
   ignoreSensorState: 0
 --- !u!114 &4744985148428767159
 MonoBehaviour:
@@ -578,8 +595,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 99998e432c125662d8991183cac37e9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 10
   topic: cam_overhead/camera_info
+  frequency: 10
   ignoreSensorState: 0
   k1: 1
   k2: 1
@@ -908,8 +925,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0488af2a38628407dba8adb3eb1a253b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 30
   topic: odom
+  frequency: 30
   ignoreSensorState: 0
   useNED: 0
   ROSPosition: {x: 0, y: 0, z: 0}
@@ -1195,38 +1212,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 46398bc5d6905ad429a6d2d973afe002, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &4432408558322206985
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2466823344739537690}
-  m_Layer: 0
-  m_Name: odom
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2466823344739537690
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4432408558322206985}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8843746628753723261}
-  m_Father: {fileID: 8664524225559225572}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4486301878068086775
 GameObject:
   m_ObjectHideFlags: 0
@@ -1473,11 +1458,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6c1407c79a8032a329313e14db655bcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 10
   topic: dr/lat_lon
+  frequency: 10
   ignoreSensorState: 1
-  lat: 0
-  lon: 0
 --- !u!114 &8137893716370307562
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1490,64 +1473,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eee95b5d1413e86d4bed3e951d06a085, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 8
   topic: Lidar/gps
+  frequency: 8
   ignoreSensorState: 0
---- !u!1 &5939089060938445646
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2694897194378912978}
-  - component: {fileID: 6111444463996866827}
-  m_Layer: 0
-  m_Name: ROS_TF
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2694897194378912978
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5939089060938445646}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8702555618869335524}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6111444463996866827
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5939089060938445646}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 78564e3e0c2d8c65cb6601a38bee530d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  linkName: odom
-  retryUntilSuccess: 1
-  rotateForROSCamera: 0
-  roll: 0
-  pitch: 0
-  yaw: 0
-  m_GlobalFrameIds:
-  - map
-  suffix: _gt
-  frequency: 10
-  ErrorOnPublish: 0
 --- !u!1 &5997850985728794168
 GameObject:
   m_ObjectHideFlags: 0
@@ -1722,8 +1650,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4fb87cf5579908965bd1e8fd9984c1f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 10
   topic: cam_onboard/image_raw/compressed
+  frequency: 10
   ignoreSensorState: 0
   quality: 75
 --- !u!114 &4400415194231580137
@@ -1738,8 +1666,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b6639050ad5a83f6a4f0de5e9d7e935, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 10
   topic: cam_onboard/image_raw
+  frequency: 10
   ignoreSensorState: 0
 --- !u!114 &7424111938258520251
 MonoBehaviour:
@@ -1753,8 +1681,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 99998e432c125662d8991183cac37e9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 10
   topic: cam_onboard/camera_info
+  frequency: 10
   ignoreSensorState: 0
   k1: 1
   k2: 1
@@ -1987,7 +1915,6 @@ Transform:
   m_Children:
   - {fileID: 6155193091040721597}
   - {fileID: 2127787486066732226}
-  - {fileID: 2694897194378912978}
   - {fileID: 1923418577117845141}
   - {fileID: 6703514752036057966}
   - {fileID: 6590584513099853624}

--- a/Runtime/Prefabs/Quadrotor.prefab
+++ b/Runtime/Prefabs/Quadrotor.prefab
@@ -108,6 +108,7 @@ GameObject:
   - component: {fileID: 4800906380731054}
   - component: {fileID: 8030836169684092610}
   - component: {fileID: 8902112791058481484}
+  - component: {fileID: 3090075413570263992}
   m_Layer: 0
   m_Name: Quadrotor
   m_TagString: robot
@@ -128,7 +129,8 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8597457138550415401}
+  - {fileID: 135919806119038934}
+  - {fileID: 6110627571383574328}
   - {fileID: 6650294322077738963}
   - {fileID: 3051417882854025666}
   - {fileID: 6552006552880646174}
@@ -174,6 +176,22 @@ MonoBehaviour:
   DistanceErrorCapFree: 10
   debugLoggingController: 0
   TargetVelocity: {x: 0, y: 0, z: 0}
+--- !u!114 &3090075413570263992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1469583607899678}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78564e3e0c2d8c65cb6601a38bee530d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  topic: /tf
+  Suffix: _gt
+  BaseLinkName: base_link
+  Frequency: 10
 --- !u!1 &1648915923807604
 GameObject:
   m_ObjectHideFlags: 0
@@ -1138,7 +1156,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8536244724804241659}
   - {fileID: 4791118420013144}
   - {fileID: 9196475552479073047}
   - {fileID: 3449743509925043727}
@@ -1423,56 +1440,6 @@ MonoBehaviour:
   topic: core/range
   frequency: 10
   ignoreSensorState: 0
---- !u!1 &1375616254144021247
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8536244724804241659}
-  - component: {fileID: 7607660689778852157}
-  m_Layer: 0
-  m_Name: ROS TF
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8536244724804241659
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1375616254144021247}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.551053, y: -8.363358, z: 8.30544}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3051417882854025666}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7607660689778852157
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1375616254144021247}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 78564e3e0c2d8c65cb6601a38bee530d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  topic: /tf
-  m_GlobalFrameIds:
-  - map
-  Suffix: _gt
-  TransformTreeRootName: odom
-  Frequency: 10
 --- !u!1 &1421537895179305450
 GameObject:
   m_ObjectHideFlags: 0
@@ -1798,39 +1765,6 @@ MonoBehaviour:
   ignoreSensorState: 1
   useNED: 0
   ROSPosition: {x: 0, y: 0, z: 0}
---- !u!1 &1914096618894252363
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8597457138550415401}
-  m_Layer: 0
-  m_Name: odom
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8597457138550415401
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1914096618894252363}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 135919806119038934}
-  - {fileID: 6110627571383574328}
-  m_Father: {fileID: 4800906380731054}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1962916537185346603
 GameObject:
   m_ObjectHideFlags: 0
@@ -2556,7 +2490,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3939394929759449381}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -2575,7 +2509,7 @@ Transform:
   - {fileID: 4341721425934453784}
   - {fileID: 8330574136197435935}
   - {fileID: 8872135822220167116}
-  m_Father: {fileID: 8597457138550415401}
+  m_Father: {fileID: 4800906380731054}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4844363478455440381
 MonoBehaviour:
@@ -3015,11 +2949,11 @@ Transform:
   m_GameObject: {fileID: 4818855960593909349}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0.38272214, z: -0, w: 0.92386353}
-  m_LocalPosition: {x: 0, y: 0.78, z: 0}
+  m_LocalPosition: {x: 0, y: 0.77999973, z: 0}
   m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
   m_ConstrainProportionsScale: 1
   m_Children: []
-  m_Father: {fileID: 8597457138550415401}
+  m_Father: {fileID: 4800906380731054}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8826866181995455972
 MonoBehaviour:

--- a/Runtime/Prefabs/lolo_auv_v1.prefab
+++ b/Runtime/Prefabs/lolo_auv_v1.prefab
@@ -147,7 +147,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: -0.0024414062, y: 0.0069999695, z: 0.2409668}
+  m_ParentAnchorPosition: {x: -0.0024414062, y: 0.0069999993, z: 0.2409668}
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
@@ -262,7 +262,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: 0.27697754, y: 0.20399952, z: -1.5510254}
+  m_ParentAnchorPosition: {x: 0.27697754, y: 0.204, z: -1.5510254}
   m_ParentAnchorRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
@@ -971,7 +971,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: -0.25195312, y: 0.2869997, z: -0.9449463}
+  m_ParentAnchorPosition: {x: -0.25195312, y: 0.287, z: -0.9449463}
   m_ParentAnchorRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
@@ -1237,7 +1237,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: 0.10205078, y: 0.19299984, z: -1.0830078}
+  m_ParentAnchorPosition: {x: 0.10205078, y: 0.193, z: -1.0830078}
   m_ParentAnchorRotation: {x: -0.5, y: 0.5, z: -0.5, w: 0.5}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
@@ -1309,38 +1309,6 @@ MonoBehaviour:
   jointName: vert_thruster_back_stbd_joint
   EffortLimit: 1000
   VelocityLimit: 1000
---- !u!1 &1803018405386258593
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7285459531232985065}
-  m_Layer: 0
-  m_Name: odom
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7285459531232985065
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1803018405386258593}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8762727590247875068}
-  m_Father: {fileID: 2802199936676877118}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1835949919394526367
 GameObject:
   m_ObjectHideFlags: 0
@@ -1741,7 +1709,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: -0.10205078, y: 0.19299984, z: -1.0830078}
+  m_ParentAnchorPosition: {x: -0.10205078, y: 0.193, z: -1.0830078}
   m_ParentAnchorRotation: {x: -0.5, y: 0.5, z: -0.5, w: 0.5}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
@@ -2218,7 +2186,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: -0.27697754, y: 0.20399952, z: -1.5510254}
+  m_ParentAnchorPosition: {x: -0.27697754, y: 0.204, z: -1.5510254}
   m_ParentAnchorRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
@@ -2551,7 +2519,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: -0.5090332, y: 0.20399952, z: -1.0400391}
+  m_ParentAnchorPosition: {x: -0.5090332, y: 0.204, z: -1.0400391}
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -3039,7 +3007,6 @@ Transform:
   - {fileID: 4729611028893047812}
   - {fileID: 8893028506487899040}
   - {fileID: 848811823009434717}
-  - {fileID: 9127437004811071234}
   - {fileID: 1941043537097059392}
   - {fileID: 2724813198870714958}
   m_Father: {fileID: 2802199936676877118}
@@ -3184,56 +3151,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 46398bc5d6905ad429a6d2d973afe002, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &4055439500778439963
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 9127437004811071234}
-  - component: {fileID: 4305443681641663497}
-  m_Layer: 0
-  m_Name: ROS_TF
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &9127437004811071234
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4055439500778439963}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.026, z: 0.053}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5797510638496293541}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4305443681641663497
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4055439500778439963}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 78564e3e0c2d8c65cb6601a38bee530d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  topic: /tf
-  m_GlobalFrameIds:
-  - map
-  Suffix: _gt
-  TransformTreeRootName: odom
-  Frequency: 10
 --- !u!1 &4083309362110725478
 GameObject:
   m_ObjectHideFlags: 0
@@ -3741,7 +3658,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: 0.25195312, y: 0.2869997, z: -0.9449463}
+  m_ParentAnchorPosition: {x: 0.25195312, y: 0.287, z: -0.9449463}
   m_ParentAnchorRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
@@ -4290,7 +4207,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: -0.38098145, y: 0.24100018, z: 1.875}
+  m_ParentAnchorPosition: {x: -0.38098145, y: 0.241, z: 1.875}
   m_ParentAnchorRotation: {x: -0.5, y: 0.5, z: -0.5, w: 0.5}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
@@ -4663,7 +4580,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: 0.5090332, y: 0.20399952, z: -1.0400391}
+  m_ParentAnchorPosition: {x: 0.5090332, y: 0.204, z: -1.0400391}
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -4832,7 +4749,7 @@ Transform:
   - {fileID: 1711407556501657870}
   - {fileID: 4907145451434052186}
   - {fileID: 3026341041441641882}
-  m_Father: {fileID: 7285459531232985065}
+  m_Father: {fileID: 2802199936676877118}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2668597019550692420
 MonoBehaviour:
@@ -4972,7 +4889,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: 0.38098145, y: 0.24100018, z: 1.875}
+  m_ParentAnchorPosition: {x: 0.38098145, y: 0.241, z: 1.875}
   m_ParentAnchorRotation: {x: -0.5, y: 0.5, z: -0.5, w: 0.5}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
@@ -5620,6 +5537,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2802199936676877118}
   - component: {fileID: 1631846539262112515}
+  - component: {fileID: 2108031976575880233}
   m_Layer: 0
   m_Name: lolo_auv_v1
   m_TagString: robot
@@ -5640,7 +5558,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7285459531232985065}
+  - {fileID: 8762727590247875068}
   - {fileID: 5797510638496293541}
   - {fileID: 675674666241882756}
   - {fileID: 8766864583192073578}
@@ -5674,6 +5592,22 @@ MonoBehaviour:
   verticalThrusterBackStbdGo: {fileID: 2233677225763660634}
   moveRpms: 800
   verticalRpms: 3000
+--- !u!114 &2108031976575880233
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7152737545778712160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78564e3e0c2d8c65cb6601a38bee530d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  topic: /tf
+  Suffix: _gt
+  BaseLinkName: base_link
+  Frequency: 10
 --- !u!1 &7181258836340888077
 GameObject:
   m_ObjectHideFlags: 0
@@ -6533,7 +6467,7 @@ ArticulationBody:
   m_Enabled: 1
   serializedVersion: 5
   m_Mass: 0.0000001
-  m_ParentAnchorPosition: {x: 0, y: 0.20300007, z: -1.2650146}
+  m_ParentAnchorPosition: {x: 0, y: 0.203, z: -1.2650146}
   m_ParentAnchorRotation: {x: 0, y: 0, z: 0, w: 1}
   m_AnchorPosition: {x: 0, y: 0, z: 0}
   m_AnchorRotation: {x: 0, y: 0, z: 0, w: 1}

--- a/Runtime/Prefabs/sam_auv_v1.prefab
+++ b/Runtime/Prefabs/sam_auv_v1.prefab
@@ -249,7 +249,7 @@ Transform:
   - {fileID: 7702723698068276516}
   - {fileID: 2160964920993597860}
   - {fileID: 8162411773536998416}
-  m_Father: {fileID: 5239274575898139297}
+  m_Father: {fileID: 1147570726954915425}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7206311383517617818
 MonoBehaviour:
@@ -905,6 +905,7 @@ GameObject:
   - component: {fileID: 2224742700551410537}
   - component: {fileID: 7094308715742057551}
   - component: {fileID: 6645243133524045330}
+  - component: {fileID: 6420392544461851451}
   m_Layer: 0
   m_Name: sam_auv_v1
   m_TagString: robot
@@ -928,7 +929,7 @@ Transform:
   - {fileID: 8436292798473102631}
   - {fileID: 5450213386245059832}
   - {fileID: 1552979989599071731}
-  - {fileID: 5239274575898139297}
+  - {fileID: 3567068247855063146}
   - {fileID: 1729294080354960234}
   - {fileID: 3353350893352951988}
   m_Father: {fileID: 0}
@@ -945,7 +946,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 618bab43988449a68c3f88b22fe6d005, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  objectToSave: {fileID: 7185973898438942457}
+  objectToSave: {fileID: 0}
 --- !u!114 &2224742700551410537
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1012,6 +1013,22 @@ MonoBehaviour:
   UseDebugInput: 0
   ResetDebugInput: 0
   ROSCoordInput: {x: 0, y: 0, z: 0}
+--- !u!114 &6420392544461851451
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1044450836926195353}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78564e3e0c2d8c65cb6601a38bee530d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  topic: /tf
+  Suffix: _gt
+  BaseLinkName: base_link
+  Frequency: 10
 --- !u!1 &1163357502922114015
 GameObject:
   m_ObjectHideFlags: 0
@@ -4914,38 +4931,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e9090ae501ff9cd459bec5271d40249c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &7185973898438942457
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5239274575898139297}
-  m_Layer: 0
-  m_Name: odom
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5239274575898139297
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7185973898438942457}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3567068247855063146}
-  m_Father: {fileID: 1147570726954915425}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7331626903056404862
 GameObject:
   m_ObjectHideFlags: 0
@@ -6307,7 +6292,9 @@ PrefabInstance:
     - {fileID: 6634857565802003842, guid: eed1d2ed1b093f5a6ab21512c8cefe12, type: 3}
     - {fileID: 4192665802447947497, guid: eed1d2ed1b093f5a6ab21512c8cefe12, type: 3}
     - {fileID: 2131255630525619321, guid: eed1d2ed1b093f5a6ab21512c8cefe12, type: 3}
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 7228304869328427846, guid: eed1d2ed1b093f5a6ab21512c8cefe12, type: 3}
+    - {fileID: 6843956064454985405, guid: eed1d2ed1b093f5a6ab21512c8cefe12, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: eed1d2ed1b093f5a6ab21512c8cefe12, type: 3}

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/TF/ROSTransformTreePublisher.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/TF/ROSTransformTreePublisher.cs
@@ -107,6 +107,7 @@ namespace VehicleComponents.ROS.Publishers
             var mapToOdomMsg = new TransformMsg
             {
                 translation = OdomLinkGO.transform.To<ENU>().translation
+                // ignore orientation, so that odom and map are aligned always.
             };
             var mapToOdom = new TransformStampedMsg(
                 new HeaderMsg(new TimeStamp(Clock.time), $"map"),
@@ -119,33 +120,6 @@ namespace VehicleComponents.ROS.Publishers
                 $"{prefix}/{BaseLinkTreeNode.name}",
                 BaseLinkTreeNode.Transform.To<ENU>());
             tfMessageList.Add(odomToBaseLink);
-
-
-
-            // if (m_GlobalFrameIds.Count > 0)
-            // {
-            //     var tfRootToGlobal = new TransformStampedMsg(
-            //         new HeaderMsg(new TimeStamp(Clock.time), m_GlobalFrameIds.Last()),
-            //         $"{prefix}/{BaseLinkTreeNode.name}",
-            //         BaseLinkTreeNode.Transform.To<ENU>());
-            //     tfMessageList.Add(tfRootToGlobal);
-            // }
-            // else
-            // {
-            //     Debug.LogWarning($"No {m_GlobalFrameIds} specified, transform tree will be entirely local coordinates.");
-            // }
-
-            // // In case there are multiple "global" transforms that are effectively the same coordinate frame, 
-            // // treat this as an ordered list, first entry is the "true" global
-            // for (var i = 1; i < m_GlobalFrameIds.Count; ++i)
-            // {
-            //     var tfGlobalToGlobal = new TransformStampedMsg(
-            //         new HeaderMsg(new TimeStamp(Clock.time), m_GlobalFrameIds[i - 1]),
-            //         m_GlobalFrameIds[i],
-            //         // Initializes to identity transform
-            //         new TransformMsg());
-            //     tfMessageList.Add(tfGlobalToGlobal);
-            // }
         }
 
         void PopulateMessage()

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/TF/TransformExtensions.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/TF/TransformExtensions.cs
@@ -11,7 +11,7 @@ public static class TransformExtensions
     {
         return new TransformMsg(
             // Using vector/quaternion To<>() because Transform.To<>() doesn't use localPosition/localRotation
-            tfUnity.localPosition.To<ENU>(),
+            tfUnity.localPosition.To<FLU>(),
             tfUnity.localRotation.To<FLU>());
     }
 

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/TF/UTMtoMapPublisher.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/TF/UTMtoMapPublisher.cs
@@ -52,10 +52,8 @@ namespace VehicleComponents.ROS.Publishers
             // why origin? so that we can tell all other tf publishers
             // in the scene to publish a "global" frame that is map_gt
             // and they wont need to do any origin shenanigans that way
-            transform.position = Vector3.zero;
-            transform.rotation = Quaternion.identity;
-
-            if(!registered)
+            transform.SetPositionAndRotation(Vector3.zero, Quaternion.identity);
+            if (!registered)
             {
                 rosCon.RegisterPublisher<TFMessageMsg>(topic);
                 registered = true;


### PR DESCRIPTION
odom objects removed from prefabs of sam, lolo, evolo, quad.
TFTree pub moved to top-level vehicle objects, no longer a "sensor".
odom frame is now aligned to ENU like map and utm.