### PR TITLE
TF debugging

### DIFF
--- a/Runtime/Prefabs/Quadrotor.prefab
+++ b/Runtime/Prefabs/Quadrotor.prefab
@@ -2948,8 +2948,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4818855960593909349}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0.38272214, z: -0, w: 0.92386353}
-  m_LocalPosition: {x: 0, y: 0.77999973, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -2999,7 +2999,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   topic: go_to_setpoint
   Target: {fileID: 6110627571383574328}
-  TeleportLocal: 1
+  TeleportFrame: 0
   UseDebugInput: 0
   ResetDebugInput: 0
   ROSCoordInput: {x: 0, y: 0, z: 0}

--- a/Runtime/Scripts/VehicleComponents/ROS/Publishers/TF/ROSTransformTreePublisher.cs
+++ b/Runtime/Scripts/VehicleComponents/ROS/Publishers/TF/ROSTransformTreePublisher.cs
@@ -37,17 +37,24 @@ namespace VehicleComponents.ROS.Publishers
 
         void OnValidate()
         {
-            if(period < Time.fixedDeltaTime)
+            if (period < Time.fixedDeltaTime)
             {
-                Debug.LogWarning($"TF Publisher update frequency set to {Frequency}Hz but Unity updates physics at {1f/Time.fixedDeltaTime}Hz. Setting to Unity's fixedDeltaTime!");
-                Frequency = 1f/Time.fixedDeltaTime;
+                Debug.LogWarning($"TF Publisher update frequency set to {Frequency}Hz but Unity updates physics at {1f / Time.fixedDeltaTime}Hz. Setting to Unity's fixedDeltaTime!");
+                Frequency = 1f / Time.fixedDeltaTime;
             }
 
-            if(topic != "/tf")
+            if (topic != "/tf")
             {
                 Debug.LogWarning($"TF Publisher topic set to {topic} but should be /tf. Setting to /tf!");
                 topic = "/tf";
             }
+
+            if (transform.rotation != Quaternion.identity)
+            {
+                Debug.LogWarning($"[{transform.name}] TF Publisher transform (probably the root robot object: {transform.name}) is not identity, this will cause issues with the TF tree! Resetting to identity.");
+                transform.rotation = Quaternion.identity;
+            }
+            
         }
 
         protected override void StartROS()
@@ -106,8 +113,7 @@ namespace VehicleComponents.ROS.Publishers
 
             var mapToOdomMsg = new TransformMsg
             {
-                translation = OdomLinkGO.transform.To<ENU>().translation
-                // ignore orientation, so that odom and map are aligned always.
+                translation = OdomLinkGO.transform.To<ENU>().translation,
             };
             var mapToOdom = new TransformStampedMsg(
                 new HeaderMsg(new TimeStamp(Clock.time), $"map"),
@@ -115,10 +121,25 @@ namespace VehicleComponents.ROS.Publishers
                 mapToOdomMsg);
             tfMessageList.Add(mapToOdom);
 
+            // base_link is the robot's main frame, so we want to publish the transform from odom to base_link
+            var rosOdomPos = ENU.ConvertFromRUF(BaseLinkTreeNode.Transform.localPosition);
+            var rosOdomOri = ENU.ConvertFromRUF(BaseLinkTreeNode.Transform.localRotation);
+            var odomToBaseLinkMsg = new TransformMsg
+            {
+                translation = new Vector3Msg(
+                    rosOdomPos.x,
+                    rosOdomPos.y,
+                    rosOdomPos.z),
+                rotation = new QuaternionMsg(
+                    rosOdomOri.x,
+                    rosOdomOri.y,
+                    rosOdomOri.z,
+                    rosOdomOri.w)
+            };
             var odomToBaseLink = new TransformStampedMsg(
                 new HeaderMsg(new TimeStamp(Clock.time), $"{prefix}/odom"),
                 $"{prefix}/{BaseLinkTreeNode.name}",
-                BaseLinkTreeNode.Transform.To<ENU>());
+                odomToBaseLinkMsg);
             tfMessageList.Add(odomToBaseLink);
         }
 


### PR DESCRIPTION
- Teleporter now takes PoseStamped and checks for unity setting and given pose's frame and warns about mismatches.
- TFPub now assumes the root robot object is the "odom" frame, and sets its orientation to 0 on validate so that odom and map are both ENU aligned. (Should probably fix this nicer to allow for non-aligned odom frames... later.)