### PR TITLE
Web mercator

### DIFF
--- a/Runtime/Prefabs/SmarcGUI/MissionPlanning/ParamGUIs/AuvAltitudePointParam.prefab
+++ b/Runtime/Prefabs/SmarcGUI/MissionPlanning/ParamGUIs/AuvAltitudePointParam.prefab
@@ -607,6 +607,184 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &503634947822329941
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7873620403623267948}
+  - component: {fileID: 1873667009927868330}
+  - component: {fileID: 2509100975129668819}
+  - component: {fileID: 1621118572002873498}
+  m_Layer: 0
+  m_Name: tol Input
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7873620403623267948
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 503634947822329941}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6641615337711045418}
+  m_Father: {fileID: 773805605021944832}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.000049591064}
+  m_SizeDelta: {x: 50, y: 20}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &1873667009927868330
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 503634947822329941}
+  m_CullTransparentMesh: 1
+--- !u!114 &2509100975129668819
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 503634947822329941}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1621118572002873498
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 503634947822329941}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2509100975129668819}
+  m_TextViewport: {fileID: 6641615337711045418}
+  m_TextComponent: {fileID: 6176391744747734635}
+  m_Placeholder: {fileID: 8047921292255600026}
+  m_VerticalScrollbar: {fileID: 0}
+  m_VerticalScrollbarEventHandler: {fileID: 0}
+  m_LayoutGroup: {fileID: 0}
+  m_ScrollSensitivity: 1
+  m_ContentType: 3
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 2
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_HideSoftKeyboard: 0
+  m_CharacterValidation: 3
+  m_RegexValue: 
+  m_GlobalPointSize: 14
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDeselect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnEndTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTouchScreenKeyboardStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 123
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+  m_RichText: 1
+  m_GlobalFontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_OnFocusSelectAll: 1
+  m_ResetOnDeActivation: 1
+  m_KeepTextSelectionVisible: 0
+  m_RestoreOriginalTextOnEscape: 1
+  m_isRichTextEditingAllowed: 0
+  m_LineLimit: 0
+  isAlert: 0
+  m_InputValidator: {fileID: 0}
+  m_ShouldActivateOnSelect: 1
 --- !u!1 &508216481333383751
 GameObject:
   m_ObjectHideFlags: 0
@@ -1363,8 +1541,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 253.30002, y: -20}
-  m_SizeDelta: {x: 138, y: 20}
+  m_AnchoredPosition: {x: 197.6, y: -20}
+  m_SizeDelta: {x: 110, y: 20}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &2451935753689442373
 GameObject:
@@ -1714,7 +1892,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 122.4, y: -20}
+  m_AnchoredPosition: {x: 110.8, y: -20}
   m_SizeDelta: {x: 85.5, y: 20}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &3213502534469687284
@@ -1853,6 +2031,163 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3390363681661347806
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7967878308344795683}
+  - component: {fileID: 6792835259126153772}
+  - component: {fileID: 8047921292255600026}
+  - component: {fileID: 8390947203970804038}
+  m_Layer: 0
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7967878308344795683
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3390363681661347806}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6641615337711045418}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6792835259126153772
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3390363681661347806}
+  m_CullTransparentMesh: 1
+--- !u!114 &8047921292255600026
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3390363681661347806}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &8390947203970804038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3390363681661347806}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &3582216638857404846
 GameObject:
   m_ObjectHideFlags: 0
@@ -1985,7 +2320,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 8.2, y: 0}
   m_SizeDelta: {x: 50, y: 20}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!222 &9166821924053337811
@@ -2284,6 +2619,194 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &4350265620696251817
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7642086723461111343}
+  - component: {fileID: 7729891154738488120}
+  - component: {fileID: 8440078565379725201}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7642086723461111343
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4350265620696251817}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 773805605021944832}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 58, y: 20}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &7729891154738488120
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4350265620696251817}
+  m_CullTransparentMesh: 1
+--- !u!114 &8440078565379725201
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4350265620696251817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Tol
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 10
+  m_fontSizeMax: 20
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4401535498540945522
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6641615337711045418}
+  - component: {fileID: 7865384611481298423}
+  m_Layer: 0
+  m_Name: Text Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6641615337711045418
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4401535498540945522}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7967878308344795683}
+  - {fileID: 3848614544413257723}
+  m_Father: {fileID: 7873620403623267948}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7865384611481298423
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4401535498540945522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: -8, y: -5, z: -8, w: -5}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &4772906242498652429
 GameObject:
   m_ObjectHideFlags: 0
@@ -2473,7 +2996,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 87, y: 20}
+  m_SizeDelta: {x: 70.4, y: 20}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &5956700660932417825
 CanvasRenderer:
@@ -2503,7 +3026,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: TargetAltitude
+  m_text: Target Alt
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -2530,8 +3053,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 12
-  m_fontSizeBase: 12
+  m_fontSize: 14
+  m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 10
@@ -2763,6 +3286,7 @@ MonoBehaviour:
   MaxDepthField: {fileID: 7200316454244156284}
   RpmField: {fileID: 7578671162651827226}
   TimeoutField: {fileID: 1800798093667412258}
+  ToleranceField: {fileID: 1621118572002873498}
 --- !u!1 &5457266654323350676
 GameObject:
   m_ObjectHideFlags: 0
@@ -3035,6 +3559,142 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5561214308012715136
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3848614544413257723}
+  - component: {fileID: 3142266087389197636}
+  - component: {fileID: 6176391744747734635}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3848614544413257723
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5561214308012715136}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6641615337711045418}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3142266087389197636
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5561214308012715136}
+  m_CullTransparentMesh: 1
+--- !u!114 &6176391744747734635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5561214308012715136}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "123\u200B"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 3
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &5696310969305345818
 GameObject:
   m_ObjectHideFlags: 0
@@ -3068,6 +3728,7 @@ RectTransform:
   - {fileID: 948555937045285144}
   - {fileID: 1750888954905399384}
   - {fileID: 492961057252806930}
+  - {fileID: 773805605021944832}
   m_Father: {fileID: 1641955731807848098}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -3368,6 +4029,43 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &6296001858806867813
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 773805605021944832}
+  m_Layer: 0
+  m_Name: Tolerance
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &773805605021944832
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6296001858806867813}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7642086723461111343}
+  - {fileID: 7873620403623267948}
+  m_Father: {fileID: 6060269555151091957}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 309.1, y: -20}
+  m_SizeDelta: {x: 70.8, y: 20}
+  m_Pivot: {x: 0, y: 1}
 --- !u!1 &6503668966536996992
 GameObject:
   m_ObjectHideFlags: 0
@@ -3455,7 +4153,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 87, y: 20}
+  m_SizeDelta: {x: 60.7, y: 20}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &1507095890463604052
 CanvasRenderer:
@@ -3485,7 +4183,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Max Depth
+  m_text: M.Depth
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3748,7 +4446,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 67.86325, y: -7.5}
-  m_SizeDelta: {x: 105, y: 15}
+  m_SizeDelta: {x: 130.2, y: 15}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &4093108356846940401
 CanvasRenderer:
@@ -3778,7 +4476,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: (AuvDepthPoint)
+  m_text: (AuvAltitudePoint)
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -4249,8 +4947,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 253.4, y: 0}
-  m_SizeDelta: {x: 138, y: 20}
+  m_AnchoredPosition: {x: 260.2, y: 0}
+  m_SizeDelta: {x: 111.2, y: 20}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &7847809477784914164
 GameObject:

--- a/Runtime/Prefabs/SmarcGUI/MissionPlanning/ParamGUIs/AuvDepthPointParam.prefab
+++ b/Runtime/Prefabs/SmarcGUI/MissionPlanning/ParamGUIs/AuvDepthPointParam.prefab
@@ -1151,6 +1151,320 @@ MonoBehaviour:
   isAlert: 0
   m_InputValidator: {fileID: 0}
   m_ShouldActivateOnSelect: 1
+--- !u!1 &1359503329366470113
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2052292988160365484}
+  - component: {fileID: 1952907475046817767}
+  - component: {fileID: 3228228437062943022}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2052292988160365484
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359503329366470113}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1803551032541169308}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 58, y: 20}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &1952907475046817767
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359503329366470113}
+  m_CullTransparentMesh: 1
+--- !u!114 &3228228437062943022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359503329366470113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Tol
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 10
+  m_fontSizeMax: 20
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1682771412234023748
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4838699263697125603}
+  - component: {fileID: 5170123715419577728}
+  - component: {fileID: 1811413894558609161}
+  - component: {fileID: 5087367847369467732}
+  m_Layer: 0
+  m_Name: tol Input
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4838699263697125603
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1682771412234023748}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7415989794063266083}
+  m_Father: {fileID: 1803551032541169308}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.000049591064}
+  m_SizeDelta: {x: 50, y: 20}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &5170123715419577728
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1682771412234023748}
+  m_CullTransparentMesh: 1
+--- !u!114 &1811413894558609161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1682771412234023748}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5087367847369467732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1682771412234023748}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1811413894558609161}
+  m_TextViewport: {fileID: 7415989794063266083}
+  m_TextComponent: {fileID: 6889198274374945109}
+  m_Placeholder: {fileID: 6298676712907834838}
+  m_VerticalScrollbar: {fileID: 0}
+  m_VerticalScrollbarEventHandler: {fileID: 0}
+  m_LayoutGroup: {fileID: 0}
+  m_ScrollSensitivity: 1
+  m_ContentType: 3
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 2
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_HideSoftKeyboard: 0
+  m_CharacterValidation: 3
+  m_RegexValue: 
+  m_GlobalPointSize: 14
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDeselect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnEndTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTouchScreenKeyboardStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 123
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+  m_RichText: 1
+  m_GlobalFontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_OnFocusSelectAll: 1
+  m_ResetOnDeActivation: 1
+  m_KeepTextSelectionVisible: 0
+  m_RestoreOriginalTextOnEscape: 1
+  m_isRichTextEditingAllowed: 0
+  m_LineLimit: 0
+  isAlert: 0
+  m_InputValidator: {fileID: 0}
+  m_ShouldActivateOnSelect: 1
 --- !u!1 &1804790789691681808
 GameObject:
   m_ObjectHideFlags: 0
@@ -1363,8 +1677,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 253.30002, y: -20}
-  m_SizeDelta: {x: 138, y: 20}
+  m_AnchoredPosition: {x: 197, y: -20}
+  m_SizeDelta: {x: 100.4, y: 20}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &2451935753689442373
 GameObject:
@@ -1714,7 +2028,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 122.4, y: -20}
+  m_AnchoredPosition: {x: 110.4, y: -20}
   m_SizeDelta: {x: 85.5, y: 20}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &3213502534469687284
@@ -1853,6 +2167,163 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3534219728258184245
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 421563215910095400}
+  - component: {fileID: 4034143355799900884}
+  - component: {fileID: 6298676712907834838}
+  - component: {fileID: 7894535888805743559}
+  m_Layer: 0
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &421563215910095400
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3534219728258184245}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7415989794063266083}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4034143355799900884
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3534219728258184245}
+  m_CullTransparentMesh: 1
+--- !u!114 &6298676712907834838
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3534219728258184245}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &7894535888805743559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3534219728258184245}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &3582216638857404846
 GameObject:
   m_ObjectHideFlags: 0
@@ -2438,6 +2909,43 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -7.5}
   m_SizeDelta: {x: 172, y: 15}
   m_Pivot: {x: 0, y: 0.5}
+--- !u!1 &4833136233406762244
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1803551032541169308}
+  m_Layer: 0
+  m_Name: Tolerance
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1803551032541169308
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4833136233406762244}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2052292988160365484}
+  - {fileID: 4838699263697125603}
+  m_Father: {fileID: 6060269555151091957}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 318.2, y: -20}
+  m_SizeDelta: {x: 70.8, y: 20}
+  m_Pivot: {x: 0, y: 1}
 --- !u!1 &4844962018891832842
 GameObject:
   m_ObjectHideFlags: 0
@@ -2763,6 +3271,143 @@ MonoBehaviour:
   MinAltitudeField: {fileID: 7200316454244156284}
   RpmField: {fileID: 7578671162651827226}
   TimeoutField: {fileID: 1800798093667412258}
+  ToleranceField: {fileID: 5087367847369467732}
+--- !u!1 &5371437186008209947
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5222465445588733596}
+  - component: {fileID: 4315583494840420919}
+  - component: {fileID: 6889198274374945109}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5222465445588733596
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5371437186008209947}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7415989794063266083}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4315583494840420919
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5371437186008209947}
+  m_CullTransparentMesh: 1
+--- !u!114 &6889198274374945109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5371437186008209947}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "123\u200B"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 3
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &5457266654323350676
 GameObject:
   m_ObjectHideFlags: 0
@@ -3068,6 +3713,7 @@ RectTransform:
   - {fileID: 948555937045285144}
   - {fileID: 1750888954905399384}
   - {fileID: 492961057252806930}
+  - {fileID: 1803551032541169308}
   m_Father: {fileID: 1641955731807848098}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -3455,7 +4101,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 87, y: 20}
+  m_SizeDelta: {x: 51.5, y: 20}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &1507095890463604052
 CanvasRenderer:
@@ -3485,7 +4131,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: MinAltitude
+  m_text: Min Alt
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3748,7 +4394,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 67.86325, y: -7.5}
-  m_SizeDelta: {x: 105, y: 15}
+  m_SizeDelta: {x: 120.5, y: 15}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &4093108356846940401
 CanvasRenderer:
@@ -3778,7 +4424,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: (AuvDepthPoint)
+  m_text: (AuvAltitudePoint)
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -4058,6 +4704,58 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &7667638792807440824
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7415989794063266083}
+  - component: {fileID: 4049590857992268017}
+  m_Layer: 0
+  m_Name: Text Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7415989794063266083
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7667638792807440824}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 421563215910095400}
+  - {fileID: 5222465445588733596}
+  m_Father: {fileID: 4838699263697125603}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4049590857992268017
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7667638792807440824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: -8, y: -5, z: -8, w: -5}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &7705543846433165725
 GameObject:
   m_ObjectHideFlags: 0
@@ -4249,7 +4947,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 253.4, y: 0}
+  m_AnchoredPosition: {x: 251.2, y: 0}
   m_SizeDelta: {x: 138, y: 20}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &7847809477784914164

--- a/Runtime/Prefabs/SmarcGUI/MissionPlanning/ParamGUIs/AuvHydrobaticPointParam.prefab
+++ b/Runtime/Prefabs/SmarcGUI/MissionPlanning/ParamGUIs/AuvHydrobaticPointParam.prefab
@@ -1,5 +1,141 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &127645767697449617
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 642834239437067172}
+  - component: {fileID: 1233042557546191316}
+  - component: {fileID: 375255110489426041}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &642834239437067172
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 127645767697449617}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2408651493960048162}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 58, y: 20}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &1233042557546191316
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 127645767697449617}
+  m_CullTransparentMesh: 1
+--- !u!114 &375255110489426041
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 127645767697449617}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Tol
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 10
+  m_fontSizeMax: 20
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &255289599056154204
 GameObject:
   m_ObjectHideFlags: 0
@@ -732,6 +868,184 @@ MonoBehaviour:
   isAlert: 0
   m_InputValidator: {fileID: 0}
   m_ShouldActivateOnSelect: 1
+--- !u!1 &2061136848522805045
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3879360577194711975}
+  - component: {fileID: 7963266557517479052}
+  - component: {fileID: 3156180680408166950}
+  - component: {fileID: 4178242632779740646}
+  m_Layer: 0
+  m_Name: tol Input
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3879360577194711975
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2061136848522805045}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3732401883583881638}
+  m_Father: {fileID: 2408651493960048162}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.000049591064}
+  m_SizeDelta: {x: 50, y: 20}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &7963266557517479052
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2061136848522805045}
+  m_CullTransparentMesh: 1
+--- !u!114 &3156180680408166950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2061136848522805045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4178242632779740646
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2061136848522805045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3156180680408166950}
+  m_TextViewport: {fileID: 3732401883583881638}
+  m_TextComponent: {fileID: 6991889060961886841}
+  m_Placeholder: {fileID: 5164085247777082786}
+  m_VerticalScrollbar: {fileID: 0}
+  m_VerticalScrollbarEventHandler: {fileID: 0}
+  m_LayoutGroup: {fileID: 0}
+  m_ScrollSensitivity: 1
+  m_ContentType: 3
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 2
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_HideSoftKeyboard: 0
+  m_CharacterValidation: 3
+  m_RegexValue: 
+  m_GlobalPointSize: 14
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDeselect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnEndTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTouchScreenKeyboardStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 123
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+  m_RichText: 1
+  m_GlobalFontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_OnFocusSelectAll: 1
+  m_ResetOnDeActivation: 1
+  m_KeepTextSelectionVisible: 0
+  m_RestoreOriginalTextOnEscape: 1
+  m_isRichTextEditingAllowed: 0
+  m_LineLimit: 0
+  isAlert: 0
+  m_InputValidator: {fileID: 0}
+  m_ShouldActivateOnSelect: 1
 --- !u!1 &2451935753689442373
 GameObject:
   m_ObjectHideFlags: 0
@@ -759,7 +1073,7 @@ RectTransform:
   m_GameObject: {fileID: 2451935753689442373}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.74, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 492961057252806930}
@@ -2282,8 +2596,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 20}
-  m_SizeDelta: {x: 110, y: 20}
+  m_AnchoredPosition: {x: -73.2, y: 20}
+  m_SizeDelta: {x: 93.63, y: 20}
   m_Pivot: {x: 1, y: 1}
 --- !u!1 &4927366960915138904
 GameObject:
@@ -2321,7 +2635,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 85.8, y: 0}
+  m_AnchoredPosition: {x: 69.9, y: 0}
   m_SizeDelta: {x: 60, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5514979256195430825
@@ -2561,6 +2875,7 @@ MonoBehaviour:
   LonField: {fileID: 5151769899253396062}
   TargetDepthField: {fileID: 2624071415871969676}
   TimeoutField: {fileID: 1800798093667412258}
+  ToleranceField: {fileID: 4178242632779740646}
   exField: {fileID: 6892536830979977110}
   eyField: {fileID: 4539469996248438658}
   ezField: {fileID: 7364925746947177412}
@@ -2700,6 +3015,58 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5420289561586912032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3732401883583881638}
+  - component: {fileID: 6942093634072968704}
+  m_Layer: 0
+  m_Name: Text Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3732401883583881638
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5420289561586912032}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7433327617241548174}
+  - {fileID: 1507813665432547542}
+  m_Father: {fileID: 3879360577194711975}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6942093634072968704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5420289561586912032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: -8, y: -5, z: -8, w: -5}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &5457266654323350676
 GameObject:
   m_ObjectHideFlags: 0
@@ -3056,6 +3423,7 @@ RectTransform:
   - {fileID: 8501316938760720930}
   - {fileID: 5507007540215444772}
   - {fileID: 492961057252806930}
+  - {fileID: 2408651493960048162}
   m_Father: {fileID: 1641955731807848098}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -3444,7 +3812,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 153.1, y: 0}
+  m_AnchoredPosition: {x: 130.9, y: 0}
   m_SizeDelta: {x: 60, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3312031175415853686
@@ -3931,6 +4299,43 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &7545953034487475076
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2408651493960048162}
+  m_Layer: 0
+  m_Name: Tolerance
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2408651493960048162
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7545953034487475076}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 642834239437067172}
+  - {fileID: 3879360577194711975}
+  m_Father: {fileID: 6060269555151091957}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 318, y: -20}
+  m_SizeDelta: {x: 70.8, y: 20}
+  m_Pivot: {x: 0, y: 1}
 --- !u!1 &7705543846433165725
 GameObject:
   m_ObjectHideFlags: 0
@@ -4299,6 +4704,142 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 250, y: 20}
   m_Pivot: {x: 0, y: 1}
+--- !u!1 &7877433343783086198
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1507813665432547542}
+  - component: {fileID: 4910085898213974134}
+  - component: {fileID: 6991889060961886841}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1507813665432547542
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7877433343783086198}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3732401883583881638}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4910085898213974134
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7877433343783086198}
+  m_CullTransparentMesh: 1
+--- !u!114 &6991889060961886841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7877433343783086198}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "123\u200B"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 3
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &8220238575818732534
 GameObject:
   m_ObjectHideFlags: 0
@@ -4443,6 +4984,163 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8220238575818732534}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &8234915989369539208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7433327617241548174}
+  - component: {fileID: 3193968704975443093}
+  - component: {fileID: 5164085247777082786}
+  - component: {fileID: 2990241052755637218}
+  m_Layer: 0
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7433327617241548174
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8234915989369539208}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3732401883583881638}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3193968704975443093
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8234915989369539208}
+  m_CullTransparentMesh: 1
+--- !u!114 &5164085247777082786
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8234915989369539208}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &2990241052755637218
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8234915989369539208}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -4681,7 +5379,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: -20}
-  m_SizeDelta: {x: 249.9, y: 20}
+  m_SizeDelta: {x: 222.3, y: 20}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &8760196554108459284
 GameObject:
@@ -4719,7 +5417,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 219.6, y: 0}
+  m_AnchoredPosition: {x: 191.8, y: 0}
   m_SizeDelta: {x: 60, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8108223655754477961

--- a/Runtime/Prefabs/SmarcGUI/MissionPlanning/ParamGUIs/GeoPointParam.prefab
+++ b/Runtime/Prefabs/SmarcGUI/MissionPlanning/ParamGUIs/GeoPointParam.prefab
@@ -1,5 +1,42 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3488513774904520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8541789985820937491}
+  m_Layer: 0
+  m_Name: Tolerance
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8541789985820937491
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3488513774904520}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3795955001009062757}
+  - {fileID: 4181302057437434124}
+  m_Father: {fileID: 1641955731807848098}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 318.1, y: -39}
+  m_SizeDelta: {x: 70.8, y: 20}
+  m_Pivot: {x: 0, y: 1}
 --- !u!1 &783065798109500700
 GameObject:
   m_ObjectHideFlags: 0
@@ -840,6 +877,351 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &4112218175242782186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3795955001009062757}
+  - component: {fileID: 2297603516221997882}
+  - component: {fileID: 5830113055882625532}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3795955001009062757
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4112218175242782186}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8541789985820937491}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 58, y: 20}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &2297603516221997882
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4112218175242782186}
+  m_CullTransparentMesh: 1
+--- !u!114 &5830113055882625532
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4112218175242782186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Tol
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 10
+  m_fontSizeMax: 20
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4188248403257495072
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4764639969691873594}
+  - component: {fileID: 3128281551805959100}
+  - component: {fileID: 422621470712235805}
+  - component: {fileID: 7554770721492290044}
+  m_Layer: 0
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4764639969691873594
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4188248403257495072}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9174443332332443776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3128281551805959100
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4188248403257495072}
+  m_CullTransparentMesh: 1
+--- !u!114 &422621470712235805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4188248403257495072}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &7554770721492290044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4188248403257495072}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &4456040972433038307
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9174443332332443776}
+  - component: {fileID: 4521601256212351573}
+  m_Layer: 0
+  m_Name: Text Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9174443332332443776
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4456040972433038307}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4764639969691873594}
+  - {fileID: 521255043200297345}
+  m_Father: {fileID: 4181302057437434124}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4521601256212351573
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4456040972433038307}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: -8, y: -5, z: -8, w: -5}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &4772906242498652429
 GameObject:
   m_ObjectHideFlags: 0
@@ -993,6 +1375,7 @@ RectTransform:
   - {fileID: 2065955339825476912}
   - {fileID: 189566930503538127}
   - {fileID: 3534447650103191913}
+  - {fileID: 8541789985820937491}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -1017,6 +1400,7 @@ MonoBehaviour:
   LatField: {fileID: 5860177524517708484}
   LonField: {fileID: 5151769899253396062}
   AltField: {fileID: 7133159887186779746}
+  ToleranceField: {fileID: 7911164307904334506}
 --- !u!222 &5675629765310258330
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1121,6 +1505,142 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_text: "\u200B"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 3
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5817814369526094653
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 521255043200297345}
+  - component: {fileID: 1110964093629960407}
+  - component: {fileID: 2742841443525802784}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &521255043200297345
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5817814369526094653}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9174443332332443776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1110964093629960407
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5817814369526094653}
+  m_CullTransparentMesh: 1
+--- !u!114 &2742841443525802784
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5817814369526094653}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "123\u200B"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -1601,6 +2121,184 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &7672177455473103577
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4181302057437434124}
+  - component: {fileID: 8833232610343820563}
+  - component: {fileID: 4051882644896020662}
+  - component: {fileID: 7911164307904334506}
+  m_Layer: 0
+  m_Name: tol Input
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4181302057437434124
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7672177455473103577}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9174443332332443776}
+  m_Father: {fileID: 8541789985820937491}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.000049591064}
+  m_SizeDelta: {x: 50, y: 20}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &8833232610343820563
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7672177455473103577}
+  m_CullTransparentMesh: 1
+--- !u!114 &4051882644896020662
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7672177455473103577}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7911164307904334506
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7672177455473103577}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4051882644896020662}
+  m_TextViewport: {fileID: 9174443332332443776}
+  m_TextComponent: {fileID: 2742841443525802784}
+  m_Placeholder: {fileID: 422621470712235805}
+  m_VerticalScrollbar: {fileID: 0}
+  m_VerticalScrollbarEventHandler: {fileID: 0}
+  m_LayoutGroup: {fileID: 0}
+  m_ScrollSensitivity: 1
+  m_ContentType: 3
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 2
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_HideSoftKeyboard: 0
+  m_CharacterValidation: 3
+  m_RegexValue: 
+  m_GlobalPointSize: 14
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDeselect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnEndTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTouchScreenKeyboardStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 123
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+  m_RichText: 1
+  m_GlobalFontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_OnFocusSelectAll: 1
+  m_ResetOnDeActivation: 1
+  m_KeepTextSelectionVisible: 0
+  m_RestoreOriginalTextOnEscape: 1
+  m_isRichTextEditingAllowed: 0
+  m_LineLimit: 0
+  isAlert: 0
+  m_InputValidator: {fileID: 0}
+  m_ShouldActivateOnSelect: 1
 --- !u!1 &7705543846433165725
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/Prefabs/SmarcGUI/MissionPlanning/SeqTSTPrefab.prefab
+++ b/Runtime/Prefabs/SmarcGUI/MissionPlanning/SeqTSTPrefab.prefab
@@ -718,6 +718,82 @@ MonoBehaviour:
   isAlert: 0
   m_InputValidator: {fileID: 0}
   m_ShouldActivateOnSelect: 1
+--- !u!1 &3150052582601087857
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 127009816948744563}
+  - component: {fileID: 8967747385155808407}
+  - component: {fileID: 6281204885954518335}
+  m_Layer: 1
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &127009816948744563
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3150052582601087857}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1687971986965756899}
+  m_Father: {fileID: 4086120369229787823}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -10}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &8967747385155808407
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3150052582601087857}
+  m_CullTransparentMesh: 1
+--- !u!114 &6281204885954518335
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3150052582601087857}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3178783564707367825
 GameObject:
   m_ObjectHideFlags: 0
@@ -910,7 +986,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 36.400024, y: -10}
-  m_SizeDelta: {x: 72.8, y: 30}
+  m_SizeDelta: {x: 72.8, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &42438729827137231
 CanvasRenderer:
@@ -1204,6 +1280,7 @@ RectTransform:
   - {fileID: 1838164246606023643}
   - {fileID: 5259042861905699448}
   - {fileID: 2714283287217582653}
+  - {fileID: 4086120369229787823}
   - {fileID: 1891068362990660485}
   - {fileID: 6753933476578001989}
   - {fileID: 7523632775657698118}
@@ -1267,6 +1344,7 @@ MonoBehaviour:
   DescriptionField: {fileID: 3720322492756557850}
   TimeoutField: {fileID: 4726558162502314425}
   DrawPathToggle: {fileID: 9115926183745870718}
+  UseWebMercatorToggle: {fileID: 8936430611344343066}
   HighlightRT: {fileID: 1891068362990660485}
   SelectedHighlightRT: {fileID: 6753933476578001989}
   PathLineRenderer: {fileID: 6388318613168989795}
@@ -1498,7 +1576,7 @@ GameObject:
   - component: {fileID: 2714283287217582653}
   - component: {fileID: 9115926183745870718}
   m_Layer: 1
-  m_Name: DrawPath
+  m_Name: DrawPathToggle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1857,6 +1935,81 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &7413071301606023053
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1687971986965756899}
+  - component: {fileID: 6002630728951627723}
+  - component: {fileID: 5589347288471509900}
+  m_Layer: 1
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1687971986965756899
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7413071301606023053}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 127009816948744563}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6002630728951627723
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7413071301606023053}
+  m_CullTransparentMesh: 1
+--- !u!114 &5589347288471509900
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7413071301606023053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7456201447297906728
 GameObject:
   m_ObjectHideFlags: 0
@@ -2092,6 +2245,228 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &8061968023549410764
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4086120369229787823}
+  - component: {fileID: 8936430611344343066}
+  m_Layer: 1
+  m_Name: WebMercToggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4086120369229787823
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8061968023549410764}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 127009816948744563}
+  - {fileID: 577590922878129685}
+  m_Father: {fileID: 153092387383816073}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 42.4, y: -15.9}
+  m_SizeDelta: {x: 137.3, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8936430611344343066
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8061968023549410764}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6281204885954518335}
+  toggleTransition: 1
+  graphic: {fileID: 5589347288471509900}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_IsOn: 1
+--- !u!1 &8779249332179169046
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 577590922878129685}
+  - component: {fileID: 2268868671640936367}
+  - component: {fileID: 547348690625046755}
+  m_Layer: 0
+  m_Name: LabelTimeout
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &577590922878129685
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8779249332179169046}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4086120369229787823}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -10.000023}
+  m_SizeDelta: {x: 118.6, y: 20}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &2268868671640936367
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8779249332179169046}
+  m_CullTransparentMesh: 1
+--- !u!114 &547348690625046755
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8779249332179169046}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Use WebMercator:'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
   m_HorizontalAlignment: 1
   m_VerticalAlignment: 512
   m_textAlignment: 65535

--- a/Runtime/Prefabs/SmarcGUI/Worldspace/PointMarker.prefab
+++ b/Runtime/Prefabs/SmarcGUI/Worldspace/PointMarker.prefab
@@ -794,6 +794,7 @@ Transform:
   - {fileID: 6584857778855209095}
   - {fileID: 1984742441284726584}
   - {fileID: 8566289295520018864}
+  - {fileID: 6030000545139450853}
   - {fileID: 1896949039799958718}
   - {fileID: 367821956143986330}
   m_Father: {fileID: 0}
@@ -820,8 +821,148 @@ MonoBehaviour:
   FloatingDescriptionText: {fileID: 328033006577698656}
   FloatingNameBackgroundRT: {fileID: 472274653448283743}
   shadowMarker: {fileID: 8566289295520018864}
+  toleranceMarker: {fileID: 6030000545139450853}
   FarAwayDistance: 30
   PointMarkerOverlayPrefab: {fileID: 7967736057898443118, guid: 163c225603251a13cbf7d87b87f8a660, type: 3}
+--- !u!1 &5958538806631749156
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6030000545139450853}
+  - component: {fileID: 4036503974596764588}
+  m_Layer: 1
+  m_Name: ToleranceMarker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &6030000545139450853
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5958538806631749156}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.4, y: 0.05, z: 0.4}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5545247269121453085}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &4036503974596764588
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5958538806631749156}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 1}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
 --- !u!1 &7211647826865169324
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/Scripts/GeoRef/GeoReference.cs
+++ b/Runtime/Scripts/GeoRef/GeoReference.cs
@@ -6,6 +6,7 @@ namespace GeoRef
     public class GeoReference: MonoBehaviour
     {
         public double Lat, Lon;
+        public bool UseWebMercator = false;
 
         GlobalReferencePoint globalRef;
 
@@ -17,7 +18,7 @@ namespace GeoRef
                 Debug.LogWarning("No GlobalReferencePoint found in the scene!");
                 return;
             }
-            var (x,z) = globalRef.GetUnityXZFromLatLon(Lat, Lon);
+            var (x,z) = globalRef.GetUnityXZFromLatLon(Lat, Lon, UseWebMercator);
             var e = 0.001f;
             var xdif = Mathf.Abs(x-transform.position.x);
             var zdif = Mathf.Abs(z-transform.position.z);
@@ -35,7 +36,7 @@ namespace GeoRef
                 Debug.LogWarning("No GlobalReferencePoint found in the scene!");
                 return;
             }
-            var (x,z) = globalRef.GetUnityXZFromLatLon(Lat, Lon);
+            var (x,z) = globalRef.GetUnityXZFromLatLon(Lat, Lon, UseWebMercator);
             transform.position = new Vector3(x, 0, z);
         }
 

--- a/Runtime/Scripts/GeoRef/GlobalReferencePoint.cs
+++ b/Runtime/Scripts/GeoRef/GlobalReferencePoint.cs
@@ -142,14 +142,29 @@ namespace GeoRef
             }
         }
 
-        public (double lat, double lon) GetLatLonFromUnityXZ(float x, float z)
+
+
+        public (double lat, double lon) GetLatLonFromUnityXZ(float x, float z, bool useWebMercator = false)
         {
-            var eastingDiff = x - transform.position.x;
-            var northingDiff = z - transform.position.z;
-            var utm_easting = UTMEasting + eastingDiff;
-            var utm_northing = UTMNorthing + northingDiff;
-            (var lat, var lon) = GetLatLonFromUTM(utm_easting, utm_northing);
-            return (lat, lon);
+            if (useWebMercator)
+            {
+                elWeb ??= new(EagerLoadType.WebMercator);
+                var eastingDiff = x - transform.position.x;
+                var northingDiff = z - transform.position.z;
+                var webmerc_easting = WebMercatorEasting + eastingDiff;
+                var webmerc_northing = WebMercatorNorthing + northingDiff;
+                (var lat, var lon) = GetLatLonFromWebMercator(webmerc_easting, webmerc_northing);
+                return (lat, lon);
+            }
+            else
+            {
+                var eastingDiff = x - transform.position.x;
+                var northingDiff = z - transform.position.z;
+                var utm_easting = UTMEasting + eastingDiff;
+                var utm_northing = UTMNorthing + northingDiff;
+                (var lat, var lon) = GetLatLonFromUTM(utm_easting, utm_northing);
+                return (lat, lon);
+            }
         }
 
         public (double easting, double northing) GetWebMercatorFromLatLon(double lat, double lon)
@@ -158,6 +173,14 @@ namespace GeoRef
             var latlon = new Coordinate(lat, lon, elWeb);
             var webmerc = latlon.WebMercator;
             return (webmerc.Easting, webmerc.Northing);
+        }
+        
+        public (double lat, double lon) GetLatLonFromWebMercator(double easting, double northing)
+        {
+            elWeb ??= new(EagerLoadType.WebMercator);
+            var webmerc = new WebMercator(easting, northing);
+            var latlon = WebMercator.ConvertWebMercatortoLatLong(webmerc, elWeb);
+            return (latlon.Latitude.ToDouble(), latlon.Longitude.ToDouble());
         }
     }
     

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvAltitudePoint.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvAltitudePoint.cs
@@ -11,6 +11,7 @@ namespace SmarcGUI.MissionPlanning.Params
         public float max_depth{get; set;}
         public float rpm{get; set;}
         public float timeout{get; set;}
+        public float tolerance{get; set;}
 
         public string ToJson()
         {
@@ -26,6 +27,7 @@ namespace SmarcGUI.MissionPlanning.Params
             max_depth = ll.max_depth;
             rpm = ll.rpm;
             timeout = ll.timeout;
+            tolerance = ll.tolerance;
         }
     }
 }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvAltitudePointGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvAltitudePointGUI.cs
@@ -10,7 +10,7 @@ namespace SmarcGUI.MissionPlanning.Params
     {
         [Header("AuvAltitudePointGUI")]
         public TMP_InputField LatField;
-        public TMP_InputField LonField, TargetAltitudeField, MaxDepthField, RpmField, TimeoutField;
+        public TMP_InputField LonField, TargetAltitudeField, MaxDepthField, RpmField, TimeoutField, ToleranceField;
 
         public double latitude
         {
@@ -86,11 +86,24 @@ namespace SmarcGUI.MissionPlanning.Params
                 NotifyPathChange();
             }
         }
+        
+        public float tolerance
+        {
+            get { return ((AuvAltitudePoint)paramValue).tolerance; }
+            set
+            {
+                var d = (AuvAltitudePoint)paramValue;
+                d.tolerance = value;
+                paramValue = d;
+                ToleranceField.text = value.ToString();
+                NotifyPathChange();
+            }
+        }
 
 
         protected override void SetupFields()
         {
-            if(latitude == 0 && longitude == 0)
+            if (latitude == 0 && longitude == 0)
             {
                 // set this to be the same as the previous geo point
                 if (ParamIndex > 0)
@@ -102,6 +115,7 @@ namespace SmarcGUI.MissionPlanning.Params
                     max_depth = previousGp.max_depth;
                     rpm = previousGp.rpm;
                     timeout = previousGp.timeout;
+                    tolerance = previousGp.tolerance;
                     guiState.Log("New LatLon set to previous.");
                 }
                 // if there is no previous geo point, set it to where the camera is looking at
@@ -115,7 +129,7 @@ namespace SmarcGUI.MissionPlanning.Params
                 }
             }
 
-            if(target_altitude == 0) target_altitude = 1;
+            if (target_altitude == 0) target_altitude = 1;
 
             LatField.text = latitude.ToString();
             LonField.text = longitude.ToString();
@@ -123,6 +137,7 @@ namespace SmarcGUI.MissionPlanning.Params
             MaxDepthField.text = max_depth.ToString();
             RpmField.text = rpm.ToString();
             TimeoutField.text = timeout.ToString();
+            ToleranceField.text = tolerance.ToString();
 
             LatField.onEndEdit.AddListener(OnLatChanged);
             LonField.onEndEdit.AddListener(OnLonChanged);
@@ -130,6 +145,7 @@ namespace SmarcGUI.MissionPlanning.Params
             MaxDepthField.onEndEdit.AddListener(OnMaxDepthChanged);
             RpmField.onEndEdit.AddListener(OnRpmChanged);
             TimeoutField.onEndEdit.AddListener(OnTimeoutChanged);
+            ToleranceField.onEndEdit.AddListener(OnToleranceChanged);
 
             fields.Add(LatField.GetComponent<RectTransform>());
             fields.Add(LonField.GetComponent<RectTransform>());
@@ -137,6 +153,7 @@ namespace SmarcGUI.MissionPlanning.Params
             fields.Add(MaxDepthField.GetComponent<RectTransform>());
             fields.Add(RpmField.GetComponent<RectTransform>());
             fields.Add(TimeoutField.GetComponent<RectTransform>());
+            fields.Add(ToleranceField.GetComponent<RectTransform>());
 
             OnSelectedChange();
         }
@@ -219,12 +236,24 @@ namespace SmarcGUI.MissionPlanning.Params
             }
             NotifyPathChange();
         }
+        
+        void OnToleranceChanged(string s)
+        {
+            try {tolerance = float.Parse(s);}
+            catch
+            {
+                guiState.Log("Invalid tolerance value");
+                OnToleranceChanged(tolerance.ToString());
+                return;
+            }
+            NotifyPathChange();
+        }
 
         
 
         public (float, float) GetXZ()
         {
-            var (tx,tz) = GetUnityXZFromLatLon(latitude, longitude);
+            var (tx, tz) = GetUnityXZFromLatLon(latitude, longitude);
             return ((float)tx, (float)tz);
         }
 

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvAltitudePointGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvAltitudePointGUI.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace SmarcGUI.MissionPlanning.Params
 {
-    public class AuvAltitudePointGUI : ParamGUI, IParamHasXZ, IParamHasY
+    public class AuvAltitudePointGUI : ParamGUI, IParamHasXZ, IParamHasY, IParamHasTolerance
     {
         [Header("AuvAltitudePointGUI")]
         public TMP_InputField LatField;
@@ -14,8 +14,9 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public double latitude
         {
-            get{return ((AuvAltitudePoint)paramValue).latitude; }
-            set{
+            get { return ((AuvAltitudePoint)paramValue).latitude; }
+            set
+            {
                 var gp = (AuvAltitudePoint)paramValue;
                 gp.latitude = value;
                 paramValue = gp;
@@ -25,8 +26,9 @@ namespace SmarcGUI.MissionPlanning.Params
         }
         public double longitude
         {
-            get{return ((AuvAltitudePoint)paramValue).longitude; }
-            set{
+            get { return ((AuvAltitudePoint)paramValue).longitude; }
+            set
+            {
                 var gp = (AuvAltitudePoint)paramValue;
                 gp.longitude = value;
                 paramValue = gp;
@@ -86,7 +88,7 @@ namespace SmarcGUI.MissionPlanning.Params
                 NotifyPathChange();
             }
         }
-        
+
         public float tolerance
         {
             get { return ((AuvAltitudePoint)paramValue).tolerance; }
@@ -130,6 +132,7 @@ namespace SmarcGUI.MissionPlanning.Params
             }
 
             if (target_altitude == 0) target_altitude = 1;
+            if (tolerance == 0) tolerance = 1;
 
             LatField.text = latitude.ToString();
             LonField.text = longitude.ToString();
@@ -160,15 +163,15 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public override List<string> GetFieldLabels()
         {
-            return new List<string> { "Lat", "Lon", "T.Alt", "MaxDepth", "RPM", "T/O" };
+            return new List<string> { "Lat", "Lon", "T.Alt", "MaxDepth", "RPM", "T/O", "Tol" };
         }
 
 
 
         void OnLatChanged(string s)
         {
-            try {latitude = double.Parse(s);}
-            catch 
+            try { latitude = double.Parse(s); }
+            catch
             {
                 guiState.Log("Invalid latitude value");
                 OnLatChanged(latitude.ToString());
@@ -179,7 +182,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnLonChanged(string s)
         {
-            try{longitude = double.Parse(s);}
+            try { longitude = double.Parse(s); }
             catch
             {
                 guiState.Log("Invalid longitude value");
@@ -191,7 +194,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnTargetAltitudeChanged(string s)
         {
-            try {target_altitude = float.Parse(s);}
+            try { target_altitude = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid target alt value");
@@ -203,7 +206,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnMaxDepthChanged(string s)
         {
-            try {max_depth = float.Parse(s);}
+            try { max_depth = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid max depth value");
@@ -215,7 +218,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnRpmChanged(string s)
         {
-            try {rpm = float.Parse(s);}
+            try { rpm = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid rpm value");
@@ -227,7 +230,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnTimeoutChanged(string s)
         {
-            try {timeout = float.Parse(s);}
+            try { timeout = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid timeout value");
@@ -236,10 +239,10 @@ namespace SmarcGUI.MissionPlanning.Params
             }
             NotifyPathChange();
         }
-        
+
         void OnToleranceChanged(string s)
         {
-            try {tolerance = float.Parse(s);}
+            try { tolerance = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid tolerance value");
@@ -249,7 +252,7 @@ namespace SmarcGUI.MissionPlanning.Params
             NotifyPathChange();
         }
 
-        
+
 
         public (float, float) GetXZ()
         {
@@ -266,7 +269,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public float GetY()
         {
-            return -max_depth+target_altitude;
+            return -max_depth + target_altitude;
         }
 
         public float GetYReference()
@@ -277,6 +280,16 @@ namespace SmarcGUI.MissionPlanning.Params
         public void SetY(float y)
         {
             target_altitude = y;
+        }
+
+        public float GetTolerance()
+        {
+            return tolerance;
+        }
+
+        public void SetTolerance(float y)
+        {
+            tolerance = y;
         }
 
     }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvAltitudePointGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvAltitudePointGUI.cs
@@ -1,4 +1,3 @@
-using GeoRef;
 using SmarcGUI.WorldSpace;
 using TMPro;
 using UnityEngine;
@@ -12,8 +11,6 @@ namespace SmarcGUI.MissionPlanning.Params
         [Header("AuvAltitudePointGUI")]
         public TMP_InputField LatField;
         public TMP_InputField LonField, TargetAltitudeField, MaxDepthField, RpmField, TimeoutField;
-
-        GlobalReferencePoint globalReferencePoint;
 
         public double latitude
         {
@@ -90,11 +87,6 @@ namespace SmarcGUI.MissionPlanning.Params
             }
         }
 
-        void Awake()
-        {
-            globalReferencePoint = FindFirstObjectByType<GlobalReferencePoint>();
-            guiState = FindFirstObjectByType<GUIState>();
-        }
 
         protected override void SetupFields()
         {
@@ -116,7 +108,7 @@ namespace SmarcGUI.MissionPlanning.Params
                 else
                 {
                     var point = guiState.GetLookAtPoint();
-                    var (lat, lon) = globalReferencePoint.GetLatLonFromUnityXZ(point.x, point.z);
+                    var (lat, lon) = GetLatLonFromUnityXZ(point.x, point.z);
                     latitude = lat;
                     longitude = lon;
                     guiState.Log("New LatLon set to where the camera is looking at.");
@@ -232,13 +224,13 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public (float, float) GetXZ()
         {
-            var (tx,tz) = globalReferencePoint.GetUnityXZFromLatLon(latitude, longitude);
+            var (tx,tz) = GetUnityXZFromLatLon(latitude, longitude);
             return ((float)tx, (float)tz);
         }
 
         public void SetXZ(float x, float z)
         {
-            var (lat, lon) = globalReferencePoint.GetLatLonFromUnityXZ(x, z);
+            var (lat, lon) = GetLatLonFromUnityXZ(x, z);
             latitude = lat;
             longitude = lon;
         }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvDepthPoint.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvDepthPoint.cs
@@ -11,6 +11,7 @@ namespace SmarcGUI.MissionPlanning.Params
         public float min_altitude{get; set;}
         public float rpm{get; set;}
         public float timeout{get; set;}
+        public float tolerance { get; set; }
 
         public string ToJson()
         {
@@ -26,6 +27,7 @@ namespace SmarcGUI.MissionPlanning.Params
             min_altitude = ll.min_altitude;
             rpm = ll.rpm;
             timeout = ll.timeout;
+            tolerance = ll.tolerance;
         }
     }
 }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvDepthPointGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvDepthPointGUI.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace SmarcGUI.MissionPlanning.Params
 {
-    public class AuvDepthPointGUI : ParamGUI, IParamHasXZ, IParamHasY
+    public class AuvDepthPointGUI : ParamGUI, IParamHasXZ, IParamHasY, IParamHasTolerance
     {
         [Header("AuvDepthPointGUI")]
         public TMP_InputField LatField;
@@ -13,8 +13,9 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public double latitude
         {
-            get{return ((AuvDepthPoint)paramValue).latitude; }
-            set{
+            get { return ((AuvDepthPoint)paramValue).latitude; }
+            set
+            {
                 var gp = (AuvDepthPoint)paramValue;
                 gp.latitude = value;
                 paramValue = gp;
@@ -24,8 +25,9 @@ namespace SmarcGUI.MissionPlanning.Params
         }
         public double longitude
         {
-            get{return ((AuvDepthPoint)paramValue).longitude; }
-            set{
+            get { return ((AuvDepthPoint)paramValue).longitude; }
+            set
+            {
                 var gp = (AuvDepthPoint)paramValue;
                 gp.longitude = value;
                 paramValue = gp;
@@ -98,7 +100,7 @@ namespace SmarcGUI.MissionPlanning.Params
                 NotifyPathChange();
             }
         }
-        
+
 
         protected override void SetupFields()
         {
@@ -130,6 +132,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
             if (target_depth == 0) target_depth = -1;
             if (min_altitude == 0) min_altitude = 1;
+            if (tolerance == 0) tolerance = 1;
 
             LatField.text = latitude.ToString();
             LonField.text = longitude.ToString();
@@ -160,13 +163,13 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public override List<string> GetFieldLabels()
         {
-            return new List<string> { "Lat", "Lon", "T.Depth", "MinAlt", "RPM", "T/O" };
+            return new List<string> { "Lat", "Lon", "T.Depth", "MinAlt", "RPM", "T/O", "Tol"  };
         }
 
 
         void OnToleranceChanged(string s)
         {
-            try {tolerance = float.Parse(s);}
+            try { tolerance = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid tolerance value");
@@ -178,8 +181,8 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnLatChanged(string s)
         {
-            try {latitude = double.Parse(s);}
-            catch 
+            try { latitude = double.Parse(s); }
+            catch
             {
                 guiState.Log("Invalid latitude value");
                 OnLatChanged(latitude.ToString());
@@ -190,7 +193,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnLonChanged(string s)
         {
-            try{longitude = double.Parse(s);}
+            try { longitude = double.Parse(s); }
             catch
             {
                 guiState.Log("Invalid longitude value");
@@ -202,7 +205,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnDepthChanged(string s)
         {
-            try {target_depth = float.Parse(s);}
+            try { target_depth = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid depth value");
@@ -214,7 +217,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnMinAltitudeChanged(string s)
         {
-            try {min_altitude = float.Parse(s);}
+            try { min_altitude = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid min altitude value");
@@ -226,7 +229,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnRpmChanged(string s)
         {
-            try {rpm = float.Parse(s);}
+            try { rpm = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid rpm value");
@@ -238,7 +241,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnTimeoutChanged(string s)
         {
-            try {timeout = float.Parse(s);}
+            try { timeout = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid timeout value");
@@ -248,11 +251,11 @@ namespace SmarcGUI.MissionPlanning.Params
             NotifyPathChange();
         }
 
-        
+
 
         public (float, float) GetXZ()
         {
-            var (tx,tz) = GetUnityXZFromLatLon(latitude, longitude);
+            var (tx, tz) = GetUnityXZFromLatLon(latitude, longitude);
             return ((float)tx, (float)tz);
         }
 
@@ -276,6 +279,16 @@ namespace SmarcGUI.MissionPlanning.Params
         public void SetY(float y)
         {
             target_depth = -y;
+        }
+        
+        public float GetTolerance()
+        {
+            return tolerance;
+        }
+
+        public void SetTolerance(float y)
+        {
+            tolerance = y;
         }
 
     }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvDepthPointGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvDepthPointGUI.cs
@@ -9,7 +9,7 @@ namespace SmarcGUI.MissionPlanning.Params
     {
         [Header("AuvDepthPointGUI")]
         public TMP_InputField LatField;
-        public TMP_InputField LonField, TargetDepthField, MinAltitudeField, RpmField, TimeoutField;
+        public TMP_InputField LonField, TargetDepthField, MinAltitudeField, RpmField, TimeoutField, ToleranceField;
 
         public double latitude
         {
@@ -85,6 +85,19 @@ namespace SmarcGUI.MissionPlanning.Params
                 NotifyPathChange();
             }
         }
+
+        public float tolerance
+        {
+            get { return ((AuvDepthPoint)paramValue).tolerance; }
+            set
+            {
+                var d = (AuvDepthPoint)paramValue;
+                d.tolerance = value;
+                paramValue = d;
+                ToleranceField.text = value.ToString();
+                NotifyPathChange();
+            }
+        }
         
 
         protected override void SetupFields()
@@ -101,6 +114,7 @@ namespace SmarcGUI.MissionPlanning.Params
                     min_altitude = previousGp.min_altitude;
                     rpm = previousGp.rpm;
                     timeout = previousGp.timeout;
+                    tolerance = previousGp.tolerance;
                     guiState.Log("New LatLon set to previous.");
                 }
                 // if there is no previous geo point, set it to where the camera is looking at
@@ -123,6 +137,7 @@ namespace SmarcGUI.MissionPlanning.Params
             MinAltitudeField.text = min_altitude.ToString();
             RpmField.text = rpm.ToString();
             TimeoutField.text = timeout.ToString();
+            ToleranceField.text = tolerance.ToString();
 
             LatField.onEndEdit.AddListener(OnLatChanged);
             LonField.onEndEdit.AddListener(OnLonChanged);
@@ -130,6 +145,7 @@ namespace SmarcGUI.MissionPlanning.Params
             MinAltitudeField.onEndEdit.AddListener(OnMinAltitudeChanged);
             RpmField.onEndEdit.AddListener(OnRpmChanged);
             TimeoutField.onEndEdit.AddListener(OnTimeoutChanged);
+            ToleranceField.onEndEdit.AddListener(OnToleranceChanged);
 
             fields.Add(LatField.GetComponent<RectTransform>());
             fields.Add(LonField.GetComponent<RectTransform>());
@@ -137,6 +153,7 @@ namespace SmarcGUI.MissionPlanning.Params
             fields.Add(MinAltitudeField.GetComponent<RectTransform>());
             fields.Add(RpmField.GetComponent<RectTransform>());
             fields.Add(TimeoutField.GetComponent<RectTransform>());
+            fields.Add(ToleranceField.GetComponent<RectTransform>());
 
             OnSelectedChange();
         }
@@ -146,6 +163,18 @@ namespace SmarcGUI.MissionPlanning.Params
             return new List<string> { "Lat", "Lon", "T.Depth", "MinAlt", "RPM", "T/O" };
         }
 
+
+        void OnToleranceChanged(string s)
+        {
+            try {tolerance = float.Parse(s);}
+            catch
+            {
+                guiState.Log("Invalid tolerance value");
+                OnToleranceChanged(tolerance.ToString());
+                return;
+            }
+            NotifyPathChange();
+        }
 
         void OnLatChanged(string s)
         {

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvDepthPointGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvDepthPointGUI.cs
@@ -1,4 +1,3 @@
-using GeoRef;
 using SmarcGUI.WorldSpace;
 using TMPro;
 using UnityEngine;
@@ -11,8 +10,6 @@ namespace SmarcGUI.MissionPlanning.Params
         [Header("AuvDepthPointGUI")]
         public TMP_InputField LatField;
         public TMP_InputField LonField, TargetDepthField, MinAltitudeField, RpmField, TimeoutField;
-
-        GlobalReferencePoint globalReferencePoint;
 
         public double latitude
         {
@@ -88,16 +85,11 @@ namespace SmarcGUI.MissionPlanning.Params
                 NotifyPathChange();
             }
         }
-
-        void Awake()
-        {
-            globalReferencePoint = FindFirstObjectByType<GlobalReferencePoint>();
-            guiState = FindFirstObjectByType<GUIState>();
-        }
+        
 
         protected override void SetupFields()
         {
-            if(latitude == 0 && longitude == 0)
+            if (latitude == 0 && longitude == 0)
             {
                 // set this to be the same as the previous geo point
                 if (ParamIndex > 0)
@@ -115,15 +107,15 @@ namespace SmarcGUI.MissionPlanning.Params
                 else
                 {
                     var point = guiState.GetLookAtPoint();
-                    var (lat, lon) = globalReferencePoint.GetLatLonFromUnityXZ(point.x, point.z);
+                    var (lat, lon) = GetLatLonFromUnityXZ(point.x, point.z);
                     latitude = lat;
                     longitude = lon;
                     guiState.Log("New LatLon set to where the camera is looking at.");
                 }
             }
 
-            if(target_depth == 0) target_depth = -1;
-            if(min_altitude == 0) min_altitude = 1;
+            if (target_depth == 0) target_depth = -1;
+            if (min_altitude == 0) min_altitude = 1;
 
             LatField.text = latitude.ToString();
             LonField.text = longitude.ToString();
@@ -231,13 +223,13 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public (float, float) GetXZ()
         {
-            var (tx,tz) = globalReferencePoint.GetUnityXZFromLatLon(latitude, longitude);
+            var (tx,tz) = GetUnityXZFromLatLon(latitude, longitude);
             return ((float)tx, (float)tz);
         }
 
         public void SetXZ(float x, float z)
         {
-            var (lat, lon) = globalReferencePoint.GetLatLonFromUnityXZ(x, z);
+            var (lat, lon) = GetLatLonFromUnityXZ(x, z);
             latitude = lat;
             longitude = lon;
         }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvHydrobaticPoint.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvHydrobaticPoint.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using NUnit.Framework.Constraints;
 
 namespace SmarcGUI.MissionPlanning.Params
 {
@@ -10,6 +11,7 @@ namespace SmarcGUI.MissionPlanning.Params
         public float target_depth{get; set;}
         public Orientation orientation{get; set;}
         public float timeout{get; set;}
+        public float tolerance { get; set; }
 
         public string ToJson()
         {
@@ -24,6 +26,7 @@ namespace SmarcGUI.MissionPlanning.Params
             target_depth = ll.target_depth;
             orientation = ll.orientation;
             timeout = ll.timeout;
+            tolerance = ll.tolerance;
         }
     }
 }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvHydrobaticPointGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvHydrobaticPointGUI.cs
@@ -1,4 +1,3 @@
-using GeoRef;
 using SmarcGUI.WorldSpace;
 using TMPro;
 using UnityEngine;
@@ -13,8 +12,6 @@ namespace SmarcGUI.MissionPlanning.Params
         public TMP_InputField LatField;
         public TMP_InputField LonField, TargetDepthField, TimeoutField;        
         public TMP_InputField exField, eyField, ezField;
-
-        GlobalReferencePoint globalReferencePoint;
 
         public double latitude
         {
@@ -90,11 +87,7 @@ namespace SmarcGUI.MissionPlanning.Params
             orientation = new Orientation(ex, ey, ez);
         }
 
-        void Awake()
-        {
-            globalReferencePoint = FindFirstObjectByType<GlobalReferencePoint>();
-            guiState = FindFirstObjectByType<GUIState>();
-        }
+
 
         protected override void SetupFields()
         {
@@ -115,7 +108,7 @@ namespace SmarcGUI.MissionPlanning.Params
                 else
                 {
                     var point = guiState.GetLookAtPoint();
-                    var (lat, lon) = globalReferencePoint.GetLatLonFromUnityXZ(point.x, point.z);
+                    var (lat, lon) = GetLatLonFromUnityXZ(point.x, point.z);
                     latitude = lat;
                     longitude = lon;
                     guiState.Log("New LatLon set to where the camera is looking at.");
@@ -249,13 +242,13 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public (float, float) GetXZ()
         {
-            var (tx,tz) = globalReferencePoint.GetUnityXZFromLatLon(latitude, longitude);
+            var (tx,tz) = GetUnityXZFromLatLon(latitude, longitude);
             return ((float)tx, (float)tz);
         }
 
         public void SetXZ(float x, float z)
         {
-            var (lat, lon) = globalReferencePoint.GetLatLonFromUnityXZ(x, z);
+            var (lat, lon) = GetLatLonFromUnityXZ(x, z);
             latitude = lat;
             longitude = lon;
         }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvHydrobaticPointGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvHydrobaticPointGUI.cs
@@ -6,17 +6,18 @@ using Unity.Robotics.ROSTCPConnector.ROSGeometry;
 
 
 namespace SmarcGUI.MissionPlanning.Params
-{    public class AuvHydrobaticPointGUI : ParamGUI, IParamHasXZ, IParamHasY, IParamHasOrientation
+{    public class AuvHydrobaticPointGUI : ParamGUI, IParamHasXZ, IParamHasY, IParamHasOrientation, IParamHasTolerance
     {
         [Header("AuvHydrobaticPointGUI")]
         public TMP_InputField LatField;
-        public TMP_InputField LonField, TargetDepthField, TimeoutField, ToleranceField;        
+        public TMP_InputField LonField, TargetDepthField, TimeoutField, ToleranceField;
         public TMP_InputField exField, eyField, ezField;
 
         public double latitude
         {
-            get{return ((AuvHydrobaticPoint)paramValue).latitude; }
-            set{
+            get { return ((AuvHydrobaticPoint)paramValue).latitude; }
+            set
+            {
                 var gp = (AuvHydrobaticPoint)paramValue;
                 gp.latitude = value;
                 paramValue = gp;
@@ -26,8 +27,9 @@ namespace SmarcGUI.MissionPlanning.Params
         }
         public double longitude
         {
-            get{return ((AuvHydrobaticPoint)paramValue).longitude; }
-            set{
+            get { return ((AuvHydrobaticPoint)paramValue).longitude; }
+            set
+            {
                 var gp = (AuvHydrobaticPoint)paramValue;
                 gp.longitude = value;
                 paramValue = gp;
@@ -104,7 +106,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         protected override void SetupFields()
         {
-            if(latitude == 0 && longitude == 0)
+            if (latitude == 0 && longitude == 0)
             {
                 // set this to be the same as the previous geo point
                 if (ParamIndex > 0)
@@ -129,7 +131,8 @@ namespace SmarcGUI.MissionPlanning.Params
                 }
             }
 
-            if(target_depth == 0) target_depth = -1;
+            if (target_depth == 0) target_depth = -1;
+            if (tolerance == 0) tolerance = 1;
 
             LatField.text = latitude.ToString();
             LonField.text = longitude.ToString();
@@ -151,7 +154,7 @@ namespace SmarcGUI.MissionPlanning.Params
             exField.onEndEdit.AddListener(OnEulerXChanged);
             eyField.onEndEdit.AddListener(OnEulerYChanged);
             ezField.onEndEdit.AddListener(OnEulerZChanged);
-            
+
 
             fields.Add(LatField.GetComponent<RectTransform>());
             fields.Add(LonField.GetComponent<RectTransform>());
@@ -167,12 +170,12 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public override List<string> GetFieldLabels()
         {
-            return new List<string> { "Lat", "Lon", "T.Depth", "T/O", "Roll", "Pitch", "Yaw" };
+            return new List<string> { "Lat", "Lon", "T.Depth", "T/O", "Roll", "Pitch", "Yaw", "Tol"  };
         }
 
         void OnToleranceChanged(string s)
         {
-            try {tolerance = float.Parse(s);}
+            try { tolerance = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid tolerance value");
@@ -184,8 +187,8 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnEulerXChanged(string s)
         {
-            try {UpdateOrientationFromEuler();}
-            catch 
+            try { UpdateOrientationFromEuler(); }
+            catch
             {
                 guiState.Log("Invalid euler X value");
                 OnEulerXChanged("0");
@@ -196,8 +199,8 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnEulerYChanged(string s)
         {
-            try {UpdateOrientationFromEuler();}
-            catch 
+            try { UpdateOrientationFromEuler(); }
+            catch
             {
                 guiState.Log("Invalid euler Y value");
                 OnEulerYChanged("0");
@@ -208,8 +211,8 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnEulerZChanged(string s)
         {
-            try {UpdateOrientationFromEuler();}
-            catch 
+            try { UpdateOrientationFromEuler(); }
+            catch
             {
                 guiState.Log("Invalid euler Z value");
                 OnEulerZChanged("0");
@@ -221,8 +224,8 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnLatChanged(string s)
         {
-            try {latitude = double.Parse(s);}
-            catch 
+            try { latitude = double.Parse(s); }
+            catch
             {
                 guiState.Log("Invalid latitude value");
                 OnLatChanged(latitude.ToString());
@@ -233,7 +236,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnLonChanged(string s)
         {
-            try{longitude = double.Parse(s);}
+            try { longitude = double.Parse(s); }
             catch
             {
                 guiState.Log("Invalid longitude value");
@@ -245,7 +248,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnDepthChanged(string s)
         {
-            try {target_depth = float.Parse(s);}
+            try { target_depth = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid depth value");
@@ -258,7 +261,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnTimeoutChanged(string s)
         {
-            try {timeout = float.Parse(s);}
+            try { timeout = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid timeout value");
@@ -268,11 +271,11 @@ namespace SmarcGUI.MissionPlanning.Params
             NotifyPathChange();
         }
 
-        
+
 
         public (float, float) GetXZ()
         {
-            var (tx,tz) = GetUnityXZFromLatLon(latitude, longitude);
+            var (tx, tz) = GetUnityXZFromLatLon(latitude, longitude);
             return ((float)tx, (float)tz);
         }
 
@@ -325,6 +328,16 @@ namespace SmarcGUI.MissionPlanning.Params
             // might be nice to have later, when there is a gui widget for setting the orientation
             // in-world
             Debug.Log("SetUnityQuat not implemented");
+        }
+        
+        public float GetTolerance()
+        {
+            return tolerance;
+        }
+
+        public void SetTolerance(float y)
+        {
+            tolerance = y;
         }
 
     }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvHydrobaticPointGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/AuvHydrobaticPointGUI.cs
@@ -10,7 +10,7 @@ namespace SmarcGUI.MissionPlanning.Params
     {
         [Header("AuvHydrobaticPointGUI")]
         public TMP_InputField LatField;
-        public TMP_InputField LonField, TargetDepthField, TimeoutField;        
+        public TMP_InputField LonField, TargetDepthField, TimeoutField, ToleranceField;        
         public TMP_InputField exField, eyField, ezField;
 
         public double latitude
@@ -78,6 +78,19 @@ namespace SmarcGUI.MissionPlanning.Params
             }
         }
 
+        public float tolerance
+        {
+            get { return ((AuvHydrobaticPoint)paramValue).tolerance; }
+            set
+            {
+                var d = (AuvHydrobaticPoint)paramValue;
+                d.tolerance = value;
+                paramValue = d;
+                ToleranceField.text = value.ToString();
+                NotifyPathChange();
+            }
+        }
+
         void UpdateOrientationFromEuler()
         {
             var ex = exField.text != "" ? float.Parse(exField.text) : 0;
@@ -102,6 +115,7 @@ namespace SmarcGUI.MissionPlanning.Params
                     target_depth = previousGp.target_depth;
                     timeout = previousGp.timeout;
                     orientation = previousGp.orientation;
+                    tolerance = previousGp.tolerance;
                     guiState.Log("New LatLon set to previous.");
                 }
                 // if there is no previous geo point, set it to where the camera is looking at
@@ -121,6 +135,7 @@ namespace SmarcGUI.MissionPlanning.Params
             LonField.text = longitude.ToString();
             TargetDepthField.text = target_depth.ToString();
             TimeoutField.text = timeout.ToString();
+            ToleranceField.text = tolerance.ToString();
             var euler = orientation.ToRPY();
             exField.text = euler.x.ToString();
             eyField.text = euler.y.ToString();
@@ -132,9 +147,11 @@ namespace SmarcGUI.MissionPlanning.Params
             LonField.onEndEdit.AddListener(OnLonChanged);
             TargetDepthField.onEndEdit.AddListener(OnDepthChanged);
             TimeoutField.onEndEdit.AddListener(OnTimeoutChanged);
+            ToleranceField.onEndEdit.AddListener(OnToleranceChanged);
             exField.onEndEdit.AddListener(OnEulerXChanged);
             eyField.onEndEdit.AddListener(OnEulerYChanged);
             ezField.onEndEdit.AddListener(OnEulerZChanged);
+            
 
             fields.Add(LatField.GetComponent<RectTransform>());
             fields.Add(LonField.GetComponent<RectTransform>());
@@ -143,6 +160,7 @@ namespace SmarcGUI.MissionPlanning.Params
             fields.Add(exField.GetComponent<RectTransform>());
             fields.Add(eyField.GetComponent<RectTransform>());
             fields.Add(ezField.GetComponent<RectTransform>());
+            fields.Add(ToleranceField.GetComponent<RectTransform>());
 
             OnSelectedChange();
         }
@@ -150,6 +168,18 @@ namespace SmarcGUI.MissionPlanning.Params
         public override List<string> GetFieldLabels()
         {
             return new List<string> { "Lat", "Lon", "T.Depth", "T/O", "Roll", "Pitch", "Yaw" };
+        }
+
+        void OnToleranceChanged(string s)
+        {
+            try {tolerance = float.Parse(s);}
+            catch
+            {
+                guiState.Log("Invalid tolerance value");
+                OnToleranceChanged(tolerance.ToString());
+                return;
+            }
+            NotifyPathChange();
         }
 
         void OnEulerXChanged(string s)

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/GeoPoint.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/GeoPoint.cs
@@ -9,6 +9,7 @@ namespace SmarcGUI.MissionPlanning.Params
         public double longitude{get; set;}
         public float altitude{get; set;}
         public readonly string rostype{ get{return "GeoPoint";} }
+        public float tolerance;
 
         public string ToJson()
         {
@@ -21,6 +22,7 @@ namespace SmarcGUI.MissionPlanning.Params
             latitude = gp.latitude;
             longitude = gp.longitude;
             altitude = gp.altitude;
+            tolerance = gp.tolerance;
         }
     }
 }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/GeoPointParamGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/GeoPointParamGUI.cs
@@ -1,4 +1,3 @@
-using GeoRef;
 using SmarcGUI.WorldSpace;
 using TMPro;
 using UnityEngine;
@@ -10,7 +9,6 @@ namespace SmarcGUI.MissionPlanning.Params
     {
         [Header("GeoPointParamGUI")]
         public TMP_InputField LatField, LonField, AltField;
-        GlobalReferencePoint globalReferencePoint;
 
         public float altitude
         {
@@ -47,12 +45,6 @@ namespace SmarcGUI.MissionPlanning.Params
         }
 
 
-        void Awake()
-        {
-            globalReferencePoint = FindFirstObjectByType<GlobalReferencePoint>();
-            guiState = FindFirstObjectByType<GUIState>();
-        }
-
         protected override void SetupFields()
         {
             if(altitude == 0 && latitude == 0 && longitude == 0)
@@ -70,7 +62,7 @@ namespace SmarcGUI.MissionPlanning.Params
                 else
                 {
                     var point = guiState.GetLookAtPoint();
-                    var (lat, lon) = globalReferencePoint.GetLatLonFromUnityXZ(point.x, point.z);
+                    var (lat, lon) = GetLatLonFromUnityXZ(point.x, point.z);
                     latitude = lat;
                     longitude = lon;
                     altitude = point.y;
@@ -143,13 +135,13 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public (float, float) GetXZ()
         {
-            var (tx,tz) = globalReferencePoint.GetUnityXZFromLatLon(latitude, longitude);
+            var (tx,tz) = GetUnityXZFromLatLon(latitude, longitude);
             return ((float)tx, (float)tz);
         }
 
         public void SetXZ(float x, float z)
         {
-            var (lat, lon) = globalReferencePoint.GetLatLonFromUnityXZ(x, z);
+            var (lat, lon) = GetLatLonFromUnityXZ(x, z);
             latitude = lat;
             longitude = lon;
         }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/GeoPointParamGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/GeoPointParamGUI.cs
@@ -5,15 +5,16 @@ using System.Collections.Generic;
 
 namespace SmarcGUI.MissionPlanning.Params
 {
-    public class GeoPointParamGUI : ParamGUI, IParamHasXZ, IParamHasY
+    public class GeoPointParamGUI : ParamGUI, IParamHasXZ, IParamHasY, IParamHasTolerance
     {
         [Header("GeoPointParamGUI")]
         public TMP_InputField LatField, LonField, AltField, ToleranceField;
 
         public float altitude
         {
-            get{return (float)((GeoPoint)paramValue).altitude; }
-            set{
+            get { return (float)((GeoPoint)paramValue).altitude; }
+            set
+            {
                 var gp = (GeoPoint)paramValue;
                 gp.altitude = value;
                 paramValue = gp;
@@ -23,8 +24,9 @@ namespace SmarcGUI.MissionPlanning.Params
         }
         public double latitude
         {
-            get{return ((GeoPoint)paramValue).latitude; }
-            set{
+            get { return ((GeoPoint)paramValue).latitude; }
+            set
+            {
                 var gp = (GeoPoint)paramValue;
                 gp.latitude = value;
                 paramValue = gp;
@@ -34,8 +36,9 @@ namespace SmarcGUI.MissionPlanning.Params
         }
         public double longitude
         {
-            get{return ((GeoPoint)paramValue).longitude; }
-            set{
+            get { return ((GeoPoint)paramValue).longitude; }
+            set
+            {
                 var gp = (GeoPoint)paramValue;
                 gp.longitude = value;
                 paramValue = gp;
@@ -43,7 +46,7 @@ namespace SmarcGUI.MissionPlanning.Params
                 NotifyPathChange();
             }
         }
-        
+
         public float tolerance
         {
             get { return ((GeoPoint)paramValue).tolerance; }
@@ -84,13 +87,15 @@ namespace SmarcGUI.MissionPlanning.Params
                 }
             }
 
+            if (tolerance == 0) tolerance = 1;
+
             UpdateTexts();
 
             LatField.onEndEdit.AddListener(OnLatChanged);
             LonField.onEndEdit.AddListener(OnLonChanged);
             AltField.onEndEdit.AddListener(OnAltChanged);
             ToleranceField.onEndEdit.AddListener(OnToleranceChanged);
-            
+
 
             fields.Add(LatField.GetComponent<RectTransform>());
             fields.Add(LonField.GetComponent<RectTransform>());
@@ -102,7 +107,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public override List<string> GetFieldLabels()
         {
-            return new List<string> { "Lat", "Lon", "Alt" };
+            return new List<string> { "Lat", "Lon", "Alt", "Tol"  };
         }
 
         void UpdateTexts()
@@ -114,7 +119,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnToleranceChanged(string s)
         {
-            try {tolerance = float.Parse(s);}
+            try { tolerance = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid tolerance value");
@@ -126,8 +131,8 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnLatChanged(string s)
         {
-            try {latitude = double.Parse(s);}
-            catch 
+            try { latitude = double.Parse(s); }
+            catch
             {
                 guiState.Log("Invalid latitude value");
                 OnLatChanged(latitude.ToString());
@@ -138,7 +143,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void OnLonChanged(string s)
         {
-            try{longitude = double.Parse(s);}
+            try { longitude = double.Parse(s); }
             catch
             {
                 guiState.Log("Invalid longitude value");
@@ -146,11 +151,11 @@ namespace SmarcGUI.MissionPlanning.Params
                 return;
             }
             NotifyPathChange();
-        }   
+        }
 
         void OnAltChanged(string s)
         {
-            try{altitude = float.Parse(s);}
+            try { altitude = float.Parse(s); }
             catch
             {
                 guiState.Log("Invalid altitude value");
@@ -164,7 +169,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public (float, float) GetXZ()
         {
-            var (tx,tz) = GetUnityXZFromLatLon(latitude, longitude);
+            var (tx, tz) = GetUnityXZFromLatLon(latitude, longitude);
             return ((float)tx, (float)tz);
         }
 
@@ -188,6 +193,16 @@ namespace SmarcGUI.MissionPlanning.Params
         public void SetY(float y)
         {
             altitude = y;
+        }
+        
+        public float GetTolerance()
+        {
+            return tolerance;
+        }
+
+        public void SetTolerance(float y)
+        {
+            tolerance = y;
         }
     }
 }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/GeoPointParamGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/GeoPointParamGUI.cs
@@ -8,7 +8,7 @@ namespace SmarcGUI.MissionPlanning.Params
     public class GeoPointParamGUI : ParamGUI, IParamHasXZ, IParamHasY
     {
         [Header("GeoPointParamGUI")]
-        public TMP_InputField LatField, LonField, AltField;
+        public TMP_InputField LatField, LonField, AltField, ToleranceField;
 
         public float altitude
         {
@@ -43,11 +43,24 @@ namespace SmarcGUI.MissionPlanning.Params
                 NotifyPathChange();
             }
         }
+        
+        public float tolerance
+        {
+            get { return ((GeoPoint)paramValue).tolerance; }
+            set
+            {
+                var gp = (GeoPoint)paramValue;
+                gp.tolerance = value;
+                paramValue = gp;
+                ToleranceField.text = value.ToString();
+                NotifyPathChange();
+            }
+        }
 
 
         protected override void SetupFields()
         {
-            if(altitude == 0 && latitude == 0 && longitude == 0)
+            if (altitude == 0 && latitude == 0 && longitude == 0)
             {
                 // set this to be the same as the previous geo point
                 if (ParamIndex > 0)
@@ -56,6 +69,7 @@ namespace SmarcGUI.MissionPlanning.Params
                     latitude = previousGp.latitude;
                     longitude = previousGp.longitude;
                     altitude = previousGp.altitude;
+                    tolerance = previousGp.tolerance;
                     guiState.Log("New GeoPoint set to previous.");
                 }
                 // if there is no previous geo point, set it to where the camera is looking at
@@ -75,10 +89,13 @@ namespace SmarcGUI.MissionPlanning.Params
             LatField.onEndEdit.AddListener(OnLatChanged);
             LonField.onEndEdit.AddListener(OnLonChanged);
             AltField.onEndEdit.AddListener(OnAltChanged);
+            ToleranceField.onEndEdit.AddListener(OnToleranceChanged);
+            
 
             fields.Add(LatField.GetComponent<RectTransform>());
             fields.Add(LonField.GetComponent<RectTransform>());
             fields.Add(AltField.GetComponent<RectTransform>());
+            fields.Add(ToleranceField.GetComponent<RectTransform>());
 
             OnSelectedChange();
         }
@@ -93,6 +110,18 @@ namespace SmarcGUI.MissionPlanning.Params
             LatField.text = latitude.ToString();
             LonField.text = longitude.ToString();
             AltField.text = altitude.ToString();
+        }
+
+        void OnToleranceChanged(string s)
+        {
+            try {tolerance = float.Parse(s);}
+            catch
+            {
+                guiState.Log("Invalid tolerance value");
+                OnToleranceChanged(tolerance.ToString());
+                return;
+            }
+            NotifyPathChange();
         }
 
         void OnLatChanged(string s)

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/LatLonParamGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/LatLonParamGUI.cs
@@ -1,4 +1,3 @@
-using GeoRef;
 using SmarcGUI.WorldSpace;
 using TMPro;
 using UnityEngine;
@@ -10,13 +9,12 @@ namespace SmarcGUI.MissionPlanning.Params
     {
         [Header("LatLonParamGUI")]
         public TMP_InputField LatField, LonField;
-
-        GlobalReferencePoint globalReferencePoint;
-
+        
         public double latitude
         {
-            get{return ((LatLon)paramValue).latitude; }
-            set{
+            get { return ((LatLon)paramValue).latitude; }
+            set
+            {
                 var gp = (LatLon)paramValue;
                 gp.latitude = value;
                 paramValue = gp;
@@ -36,11 +34,6 @@ namespace SmarcGUI.MissionPlanning.Params
             }
         }
 
-        void Awake()
-        {
-            globalReferencePoint = FindFirstObjectByType<GlobalReferencePoint>();
-            guiState = FindFirstObjectByType<GUIState>();
-        }
 
         protected override void SetupFields()
         {
@@ -58,7 +51,7 @@ namespace SmarcGUI.MissionPlanning.Params
                 else
                 {
                     var point = guiState.GetLookAtPoint();
-                    var (lat, lon) = globalReferencePoint.GetLatLonFromUnityXZ(point.x, point.z);
+                    var (lat, lon) = GetLatLonFromUnityXZ(point.x, point.z);
                     latitude = lat;
                     longitude = lon;
                     guiState.Log("New LatLon set to where the camera is looking at.");
@@ -112,13 +105,13 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public (float, float) GetXZ()
         {
-            var (tx,tz) = globalReferencePoint.GetUnityXZFromLatLon(latitude, longitude);
+            var (tx,tz) = GetUnityXZFromLatLon(latitude, longitude);
             return ((float)tx, (float)tz);
         }
 
         public void SetXZ(float x, float z)
         {
-            var (lat, lon) = globalReferencePoint.GetLatLonFromUnityXZ(x, z);
+            var (lat, lon) = GetLatLonFromUnityXZ(x, z);
             latitude = lat;
             longitude = lon;
         }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/ParamGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Params/ParamGUI.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using GeoRef;
 using SmarcGUI.MissionPlanning.Tasks;
 using TMPro;
 using UnityEngine;
@@ -8,39 +9,41 @@ using UnityEngine.UI;
 
 namespace SmarcGUI.MissionPlanning.Params
 {
-    public class ParamGUI : 
-    MonoBehaviour, 
-    IListItem, 
+    public class ParamGUI :
+    MonoBehaviour,
+    IListItem,
     IHeightUpdatable,
     IPointerClickHandler,
-    IPointerExitHandler, 
+    IPointerExitHandler,
     IPointerEnterHandler
     {
         [Header("ParamGUI")]
         public TMP_Text Label;
         public RectTransform HighlightRT;
-        
+
         protected IDictionary paramsDict;
-        public string ParamKey{get; protected set;}
+        public string ParamKey { get; protected set; }
         protected TaskGUI taskgui;
 
         protected IList paramsList;
-        public int ParamIndex{get; protected set;}
+        public int ParamIndex { get; protected set; }
         protected ListParamGUI listParamGUI;
-        
+
         protected MissionPlanStore missionPlanStore;
         protected GUIState guiState;
 
         protected RectTransform rt;
 
         protected List<RectTransform> fields = new();
- 
+
+        GlobalReferencePoint globalReferencePoint;
+
         public object paramValue
         {
-            get => paramsDict!=null? paramsDict[ParamKey] : paramsList[ParamIndex];
+            get => paramsDict != null ? paramsDict[ParamKey] : paramsList[ParamIndex];
             protected set
             {
-                if(paramsDict!=null)
+                if (paramsDict != null)
                     paramsDict[ParamKey] = value;
                 else
                     paramsList[ParamIndex] = value;
@@ -51,16 +54,48 @@ namespace SmarcGUI.MissionPlanning.Params
         {
             missionPlanStore = FindFirstObjectByType<MissionPlanStore>();
             guiState = FindFirstObjectByType<GUIState>();
+            globalReferencePoint = FindFirstObjectByType<GlobalReferencePoint>();
+
             rt = GetComponent<RectTransform>();
-            if(HighlightRT == null)
+            if (HighlightRT == null)
             {
                 HighlightRT = transform.Find("Highlight").GetComponent<RectTransform>();
                 HighlightRT.gameObject.SetActive(false);
             }
-            if(HighlightRT == null)
+            if (HighlightRT == null)
             {
                 Debug.LogError("HighlightRT is null in ParamGUI and could not be found");
             }
+        }
+
+        // We wrap the global reference point methods to allow
+        // sub-classes to use them without needing to know about the tstgui stuff.
+        protected (double, double) GetLatLonFromUnityXZ(float x, float z)
+        {
+            if (globalReferencePoint == null)
+            {
+                globalReferencePoint = FindFirstObjectByType<GlobalReferencePoint>();
+                if (globalReferencePoint == null)
+                {
+                    Debug.LogError("GlobalReferencePoint is null in ParamGUI");
+                    return (0, 0);
+                }
+            }
+            return globalReferencePoint.GetLatLonFromUnityXZ(x, z, taskgui.tstGUI.PlanInWebMercator);
+        }
+
+        protected (float x, float z) GetUnityXZFromLatLon(double lat, double lon)
+        {
+            if (globalReferencePoint == null)
+            {
+                globalReferencePoint = FindFirstObjectByType<GlobalReferencePoint>();
+                if (globalReferencePoint == null)
+                {
+                    Debug.LogError("GlobalReferencePoint is null in ParamGUI");
+                    return (0, 0);
+                }
+            }
+            return globalReferencePoint.GetUnityXZFromLatLon(lat, lon, taskgui.tstGUI.PlanInWebMercator);
         }
 
         public void SetParam(IDictionary paramsDict, string paramKey, TaskGUI taskgui)
@@ -72,10 +107,11 @@ namespace SmarcGUI.MissionPlanning.Params
             SetupFields();
         }
         public void SetParam(IList paramsList, int paramIndex, ListParamGUI listParamGUI)
-        {   
+        {
             this.paramsList = paramsList;
             this.ParamIndex = paramIndex;
             this.listParamGUI = listParamGUI;
+            this.taskgui = listParamGUI.taskgui; // the taskgui is the one that contains this list param gui
             UpdateLabel();
             SetupFields();
             ReArrangeForList();
@@ -83,7 +119,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         void UpdateLabel()
         {
-            if(Label == null) return;
+            if (Label == null) return;
             Label.text = ParamKey ?? ParamIndex.ToString();
         }
 
@@ -110,8 +146,8 @@ namespace SmarcGUI.MissionPlanning.Params
 
         protected void NotifyPathChange()
         {
-            if(taskgui != null) taskgui.OnParamChanged();
-            if(listParamGUI != null) listParamGUI.OnParamChanged();
+            if (taskgui != null) taskgui.OnParamChanged();
+            if (listParamGUI != null) listParamGUI.OnParamChanged();
         }
 
         protected virtual void OnSelectedChange()
@@ -140,18 +176,18 @@ namespace SmarcGUI.MissionPlanning.Params
         public void UpdateHeight()
         {
             float selfHeight = 5;
-            foreach(Transform child in transform)
+            foreach (Transform child in transform)
             {
-                if(child.gameObject.activeSelf)
+                if (child.gameObject.activeSelf)
                     selfHeight += child.GetComponent<RectTransform>().sizeDelta.y;
             }
-            
+
             rt.sizeDelta = new Vector2(rt.sizeDelta.x, selfHeight);
         }
 
         public void ReArrangeForList()
         {
-            if(listParamGUI == null) return;
+            if (listParamGUI == null) return;
             // we want to re-arrange all the fields in of this param
             // into one line, without any labels, without changing their sizes.
             // this is because the list param gui will take care of the labels for _all of the items_.
@@ -173,11 +209,11 @@ namespace SmarcGUI.MissionPlanning.Params
             // then, move all the fields to this new parent
             float totalChildrenWidth = 0;
             float maxChildHeight = 0;
-            foreach(var field in fields)
+            foreach (var field in fields)
             {
                 field.transform.SetParent(fieldsParent.transform);
                 totalChildrenWidth += field.sizeDelta.x;
-                if(field.sizeDelta.y > maxChildHeight)
+                if (field.sizeDelta.y > maxChildHeight)
                     maxChildHeight = field.sizeDelta.y;
             }
 
@@ -195,33 +231,33 @@ namespace SmarcGUI.MissionPlanning.Params
             labelText.enableAutoSizing = true;
             Label = labelText; // change the label of the param to this one
 
-            if(rt == null) rt = GetComponent<RectTransform>();
+            if (rt == null) rt = GetComponent<RectTransform>();
             var widthRemainingAfterLabel = rt.sizeDelta.x - labelWidth;
-            
+
             rt.sizeDelta = new Vector2(rt.sizeDelta.x, maxChildHeight);
             // if the total width of the children is greater than the width of the parent, we need to resize them
             // so that they fit in the parent
-            if(totalChildrenWidth > widthRemainingAfterLabel)
+            if (totalChildrenWidth > widthRemainingAfterLabel)
             {
                 var diff = totalChildrenWidth - widthRemainingAfterLabel;
                 var per = diff / fields.Count;
-                foreach(var field in fields)
+                foreach (var field in fields)
                 {
                     field.sizeDelta = new Vector2(field.sizeDelta.x - per, field.sizeDelta.y);
                 }
                 totalChildrenWidth -= diff;
             }
             // set the size of the new parent to be the sum of all the children widths, and the max height of the children
-            fieldsRT.sizeDelta = new Vector2(totalChildrenWidth+labelWidth, maxChildHeight);
+            fieldsRT.sizeDelta = new Vector2(totalChildrenWidth + labelWidth, maxChildHeight);
             fieldsRT.anchoredPosition = Vector2.zero;
             fieldsRT.pivot = new Vector2(0, 0.5f);
             fieldsRT.anchorMin = new Vector2(0, 0.5f);
             fieldsRT.anchorMax = new Vector2(0, 0.5f);
 
             // disable all other children of this object
-            foreach(Transform child in transform)
+            foreach (Transform child in transform)
             {
-                if(child != fieldsParent.transform)
+                if (child != fieldsParent.transform)
                     child.gameObject.SetActive(false);
             }
 
@@ -229,7 +265,7 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public void OnPointerClick(PointerEventData eventData)
         {
-            if(eventData.button == PointerEventData.InputButton.Right)
+            if (eventData.button == PointerEventData.InputButton.Right)
             {
                 var contextMenu = guiState.CreateContextMenu();
                 contextMenu.SetItem(eventData.position, (IListItem)this);
@@ -238,12 +274,14 @@ namespace SmarcGUI.MissionPlanning.Params
 
         public void OnPointerEnter(PointerEventData eventData)
         {
-            if(HighlightRT != null) HighlightRT.gameObject.SetActive(true);
+            if (HighlightRT != null) HighlightRT.gameObject.SetActive(true);
         }
 
         public void OnPointerExit(PointerEventData eventData)
         {
-            if(HighlightRT != null) HighlightRT.gameObject.SetActive(false);
+            if (HighlightRT != null) HighlightRT.gameObject.SetActive(false);
         }
+        
+
     }
 }

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Tasks/TSTGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Tasks/TSTGUI.cs
@@ -18,12 +18,14 @@ namespace SmarcGUI.MissionPlanning.Tasks
         public TMP_InputField DescriptionField;
         public TMP_InputField TimeoutField;
         public Toggle DrawPathToggle;
+        public Toggle UseWebMercatorToggle;
         public RectTransform HighlightRT;
         public RectTransform SelectedHighlightRT;
         public LineRenderer PathLineRenderer;        
 
         bool isSelected = false;
         List<TaskGUI> taskGUIs = new();
+        public bool PlanInWebMercator => UseWebMercatorToggle.isOn;
 
 
         MissionPlanStore missionPlanStore;

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Tasks/TaskGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Tasks/TaskGUI.cs
@@ -50,7 +50,7 @@ namespace SmarcGUI.MissionPlanning.Tasks
 
         MissionPlanStore missionPlanStore;
         GUIState guiState;
-        TSTGUI tstGUI;
+        public TSTGUI tstGUI{ get; private set; }
         RectTransform rt;
         float baseHeight;
         Image RunButtonImage;

--- a/Runtime/Scripts/SmarcGUI/MissionPlanning/Tasks/TaskGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/MissionPlanning/Tasks/TaskGUI.cs
@@ -102,6 +102,8 @@ namespace SmarcGUI.MissionPlanning.Tasks
                 if(paramgui is IParamHasY paramY) pointmarker.SetYParam(paramY);
                 if(paramgui is IParamHasHeading paramH) pointmarker.SetHeadingParam(paramH);
                 if(paramgui is IParamHasOrientation paramO) pointmarker.SetOrientationParam(paramO);
+                if(paramgui is IParamHasTolerance paramT) pointmarker.SetToleranceParam(paramT);
+                pointmarker.OnParamChanged();
                 pointmarkers.Add(pointmarker);
                 return pointmarker;
             }

--- a/Runtime/Scripts/SmarcGUI/RobotGUI.cs
+++ b/Runtime/Scripts/SmarcGUI/RobotGUI.cs
@@ -396,8 +396,9 @@ namespace SmarcGUI
             if(ghostTF == null) return;
             if(pos.latitude == 0 && pos.longitude == 0) return;
             if(ghostTF.gameObject.activeSelf == false) ghostTF.gameObject.SetActive(true);
-            
-            var (x,z) = globalReferencePoint.GetUnityXZFromLatLon(pos.latitude, pos.longitude);
+
+            bool useWebMercator = InfoSource != InfoSource.SIM;
+            var (x, z) = globalReferencePoint.GetUnityXZFromLatLon(pos.latitude, pos.longitude, useWebMercator);
             ghost.UpdatePosition(new Vector3(x, pos.altitude, z));
         }
 

--- a/Runtime/Scripts/SmarcGUI/WorldSpace/IParamHasTolerance.cs
+++ b/Runtime/Scripts/SmarcGUI/WorldSpace/IParamHasTolerance.cs
@@ -1,0 +1,8 @@
+namespace SmarcGUI.WorldSpace
+{
+    public interface IParamHasTolerance
+    {
+        public float GetTolerance();
+        public void SetTolerance(float y);
+    }
+}

--- a/Runtime/Scripts/SmarcGUI/WorldSpace/IParamHasTolerance.cs.meta
+++ b/Runtime/Scripts/SmarcGUI/WorldSpace/IParamHasTolerance.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dbdb13ae450b1bf439901dad2f4e7652


### PR DESCRIPTION
- #185 
- And fixes the webmap projection differing from the assumed-UTM projection of everything else. Mission related stuff (ghost vehicles, task markers etc) in-world now use the WebMercator projection. 


> This means any sim->mqtt->sim round-trips will result in ghost and simulated vehicles to not coincide anymore! The sim objects are in "utm" projection, and their ghosts are in the webmercator projection!