### PR TITLE
Refine force point selection logic

### DIFF
--- a/Runtime/Scripts/Force/ForcePoint.cs
+++ b/Runtime/Scripts/Force/ForcePoint.cs
@@ -124,7 +124,12 @@ namespace Force
             var waterModels = FindObjectsByType<WaterQueryModel>(FindObjectsSortMode.None);
             if (waterModels.Length > 0) waterModel = waterModels[0];
 
-            allForcePoints = body.gameObject.GetComponentsInChildren<ForcePoint>();
+            var tag = body.gameObject.tag;
+            allForcePoints = body.gameObject.GetComponentsInChildren<ForcePoint>()
+                .Where(fp => (fp.ConnectedArticulationBody != null && fp.ConnectedArticulationBody.gameObject.CompareTag(tag)) ||
+                             (fp.ConnectedRigidbody != null && fp.ConnectedRigidbody.gameObject.CompareTag(tag)))
+                .ToArray();
+
             if (AutomaticCenterOfGravity)
             {
                 body.automaticCenterOfMass = false;


### PR DESCRIPTION
Filter force points based on connected bodies' tags.

An alternative approach would be to add:
`public MixedBody Body  => body;`
and then use:
`.Where(fp => fp.Body.gameObject.CompareTag(tag))`

But this change would require moving forcepoints finding and automatic center of gravity code to a `Start` function since MixedBody is initialized in `Awake`