### PR TITLE
Flipped feedback for prismatic joint

### DIFF
--- a/Runtime/Scripts/VehicleComponents/Actuators/Prismatic.cs
+++ b/Runtime/Scripts/VehicleComponents/Actuators/Prismatic.cs
@@ -31,7 +31,7 @@ namespace VehicleComponents.Actuators
 
         public float GetCurrentValue()
         {
-            return (1 - (mixedBody.jointPosition[0] - _minimumPos) / (_maximumPos - _minimumPos)) * 100;
+            return ((mixedBody.jointPosition[0] - _minimumPos) / (_maximumPos - _minimumPos)) * 100;
         }
 
         new public void FixedUpdate()


### PR DESCRIPTION
The feedback for the prismatic joint (LCG mainly atm) was flipped. Set it to 100, reports back 0 in feedback.

This removes the inversion.

Discovered this because David reported it didn't align with the real vehicle.

